### PR TITLE
Nits and typos

### DIFF
--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -23,7 +23,7 @@ organisation = "NLnet Labs"
 
 .# Abstract
 
-The introduction of many new transport portocols for DNS in recent years
+The introduction of many new transport protocols for DNS in recent years
 (DoT, DoH, DoQ)
 significantly increases the complexity of DNS stub
 resolvers that want to support these protocols. A practical way forward
@@ -47,7 +47,7 @@ for example, for large responses, TCP is used, also on port 53.
 
 DoH
 
-: DNS over HTTPS as described in [@RFC8484]. 
+: DNS over HTTPS as described in [@RFC8484].
 
 DoT
 
@@ -79,7 +79,7 @@ consider an interface name.
 
 # Introduction
 
-The introduction of many new transport portocols for DNS in recent years
+The introduction of many new transport protocols for DNS in recent years
 (DoT, DoH, DoQ)
 significantly increases the complexity of DNS stub
 resolvers that want to support these protocols. In addition,
@@ -91,7 +91,7 @@ is to have a DNS client proxy in the host operating system.
 A local proxy may provide some benefit to short-lived applications by
 caching results. In particular if the system uses a so called 'public
 DNS resolver'. In general we assume that the cache is tagged according
-to the source of a reply and the transport it is received on. 
+to the source of a reply and the transport it is received on.
 
 
 This allows
@@ -104,9 +104,9 @@ capabilities and actual transports that are available.
 
 
 With respect to DNSSEC, we assume that an application that needs
-DNSSEC validation, for example, for DANE validation or SSHFP, will 
+DNSSEC validation, for example, for DANE validation or SSHFP, will
 perform the DNSSEC validation within the application itself and does not
-trust the proxy. The proxy can ofcourse do DNSSEC validation as well.
+trust the proxy. The proxy can of course do DNSSEC validation as well.
 Important however, is that an untrusted proxy cannot provide an application
 with a traditional (unsigned) trust anchor.
 
@@ -118,7 +118,7 @@ third level is where the application also specifies which transports
 (Do53, DoT, DoH, DoQ) are allowed to be used. A final transport parameter
 is the outgoing interface that is to be used.
 
-For authentication we can have a mix of PKI and DANE. Options are one of 
+For authentication we can have a mix of PKI and DANE. Options are one of
 the two and not the other, both or one of the two.
 
 A poorly constructed DNS client proxy may forward DNS packets without
@@ -126,9 +126,9 @@ properly handling of EDNS(0) options. To detect and prevent this,
 we introduce an option that limits the connection to host-local, link-local,
 or site-local. The requirement on a conforming DNS client proxy is to
 check where a request comes from and compare this to the option in
-the request (if any). And error is returned if there is a mismatch.
+the request (if any). An error is returned if there is a mismatch.
 
-In a reponse, the proxy reports the interface, resolver, and transport
+In a response, the proxy reports the interface, resolver, and transport
 used.
 
 In the ideal case, the host operating system provides applications with a
@@ -148,7 +148,7 @@ when, and only when, they appear in all capitals, as shown here.
 
 # Description
 
-This document introduces the new EDNS(0) options, and one new status code.
+This document introduces the new EDNS(0) options, and one new response code.
 This first option, called PROXY CONTROL Option, specifies which transports
 a proxy should use to connect to a recursive resolver.
 
@@ -280,9 +280,9 @@ client proxy. The U flag specifies no encryption, the UA flag, at
 least unauthenticated encryption and the A flag require authenticated
 encryptions. With the U, UA, and A flags clear, an effort is made to
 reach authenticated encryption, if that fails unauthenticated encryption
-and if that fails, fall back to an unencryption transport.
+and if that fails, fall back to an unencrypted transport.
 The P and D flags allow the application to require
-a specfic authentication mechanism (PKI or DANE). When both flags are set,
+a specific authentication mechanism (PKI or DANE). When both flags are set,
 PKI and DANE are required together. If no flags are set, are least one of
 the two has to succeed if authenticated encryption is required.
 
@@ -293,26 +293,26 @@ to allow (A53,AT,AH2,AH3,AQ) or disallow (D53,DT,DH2,DH3,DQ) the use of the
 transport. There is space to add more transports later.
 
 To future proof applications, there is a single flag DO, that disallows
-transports that are not explicitly listed. Which this flag clear,
+transports that are not explicitly listed. With this flag clear,
 the application allows future transports. With the flag set, the
 application has to explicitly list which transports can be used.
 For example, by setting only DO and AT, the application forces the
 use of DoT.
 
-Finally, an application can specify it's own resolvers or rely on the
+Finally, an application can specify its own resolvers or rely on the
 resolvers that are know to the proxy. If ADN Length and Addr Length
 are both zero, then the application requests to resolvers known to
 the proxy. [Note: it is unclear at the moment what to do with any
 Service Parameters]
 
 If the application specifies only an authentication-domain-name then the
-proxy is expect to resolve the name to addresses. If only addresses
+proxy is expected to resolve the name to addresses. If only addresses
 are specified then the proxy assumes that no name is known (though
 a PKI certificate may include an address literal in the subjectAltName).
 If both a name and address are specified then the proxy will use the
 specified addresses and use the name for authentication.
 
-To simplify the encoding of the option, an option with addresses with
+To simplify the encoding of the option, an option with addresses will
 have either IPv4 or IPv6 addresses. If the application wants to specify
 both IPv4 and IPv6 address for a certain authentication-domain-name
 then it has to include two options.
@@ -339,11 +339,11 @@ OPTION-CODE
 
 OPTION-LENGTH
 
-: Lenght of this option excluding the OPTION-CODE and OPTION-LENGTH fields
+: Length of this option excluding the OPTION-CODE and OPTION-LENGTH fields
 
 Scope
 
-: Scope of the source address of a request. Scope can have the following 
+: Scope of the source address of a request. Scope can have the following
 values:
 
      Value | Scope
@@ -354,8 +354,8 @@ values:
      3     | Site local
      4     | Global
 
-The purpose of this option is deal with badly implemented proxy that forward
-DNS traffic without first removing any EDNS(0) options. The option request
+The purpose of this option is to deal with badly implemented proxies that forward
+DNS traffic without first removing any EDNS(0) options. The option requests
 the DNS proxy that processes the option to report the scope of the source
 address. The application can specify that the connection between the stub
 resolver and the proxy should have, for example, at most host local scope.
@@ -407,19 +407,20 @@ ANCHORS-P7S
 
 This option provides DNSSEC trust anchors as described in [@RFC7958].
 
+
 # Protocol Specification
 
 # Client Processing
 
 A stub resolver that wishes to use the PROXY CONTROL Option includes the
-option in all outgoing DNS requests that require privacy. The option 
+option in all outgoing DNS requests that require privacy. The option
 should be initialized according to the needs of the application.
 In addition the PROXY SCOPE Option can be added. In requests, the Scope
 field is set to largest scope that the application can accept.
 
 If the stub resolver receives a reply without a PROXY CONTROL Option
 included in the reply, then stub resolver has to assume that traffic will
-have Do%3 levels of privacy.  Similarly, a lack of a PROXY SCOPE Option 
+have Do53 levels of privacy.  Similarly, a lack of a PROXY SCOPE Option
 implies a global scope.
 
 If the stub resolver receives a BADPROXYPOLICY error then the proxy was
@@ -428,18 +429,18 @@ modifies the options to show what it can do.
 
 ## Probing
 
-In cases where the stub resolvers expects a local DNS proxy, or where the
-stub resolver has (a limited) fall back to more private transports, or 
+In cases where the stub resolver expects a local DNS proxy, or where the
+stub resolver has (a limited) fall back to more private transports, or
 when the security policy of the application is such that is better to fail
-then the send queries over Do53, the stub resolver first sends probing
-query to verify that the proxy supports the PROXY CONTROL and 
+than send queries over Do53, the stub resolver first sends a probing
+query to verify that the proxy supports the PROXY CONTROL and
 PROXY SCOPE options.
 
-This request queries "resolver.arpa". The proxy MUST implement this as a 
+This request queries "resolver.arpa". The proxy MUST implement this as a
 Special Use Domain Name. The actual response is not important. The
 important part is that the proxy returns PROXY CONTROL and PROXY SCOPE
-options as described in the this documents and optionally sets
-the result to BADPROXYPOLICY specified policy.
+options as described in this document and optionally sets
+the response code to BADPROXYPOLICY specified policy.
 
 ## Trust Anchor
 
@@ -452,7 +453,7 @@ obtain the trust anchor XML file and the signature over the trust anchor.
 For this reason, it makes sense to let the proxy cache this information.
 
 If the local operating system does not provide a DNSSEC trust anchor, then
-the application can ask the proxy. The stub resolver adds the TRUST ANCHOR 
+the application can ask the proxy. The stub resolver adds the TRUST ANCHOR
 Option with ANCHORS-XML-LENGTH and ANCHORS-P7S-LENGTH. If the proxy
 returns both an ANCHORS-XML and an ANCHORS-P7S, then the application verifies
 the trust anchor using the trust anchor certificate (which needs to come
@@ -463,34 +464,34 @@ with the application).
 Proxies are encouraged to cache options that appear in requests under the
 assumption that a stub resolver will send multiple requests. If a proxy
 caches DNS responses then the proxy MUST tag cached responses with the
-properties of the DNS transport. When responding the later requests,
-then proxy returns a cached entry only if the parameters of the DNS transport
+properties of the DNS transport. When responding to later requests,
+the proxy returns a cached entry only if the parameters of the DNS transport
 match what is specified in the request.
 
 When a proxy receives a new set of requirements, the proxy compiles a list of
-addresses to connect to and per address a list of transports to try.
+addresses to connect to and a list of transports to try per address.
 The proxy SHOULD prefer more private transports over less private ones.
 
-If the proxy cannot obtain a connect to a recursive resolver in a way that
+If the proxy cannot obtain a connection to a recursive resolver in a way that
 matches the provided policy, then the proxy sets the BADPROXYPOLICY
-status in the reply. In addition the proxy SHOULD try to find at least
+response code in the reply. In addition the proxy SHOULD try to find at least
 one connection to a recursive resolver. If the proxy did not find an
-alternative connection to recursive resolver (also if it didn't try) then
-the proxy include a PROXY POLICY Option with all flags set to zero,
+alternative connection to a recursive resolver (also if it didn't try) then
+the proxy includes a PROXY POLICY Option with all flags set to zero,
 and with  ADN Length, Addr Length, and SvcParams Length set to zero as well.
 
-If the proxy does have one or more alternative connections to resursive
+If the proxy does have one or more alternative connections to recursive
 resolvers then the proxy generates options with the properties of those
 connection, with a maximum of three connections.
 
 If the proxy finds a PROXY SCOPE Option, then it calculates the scope from
 the source address. If the scope is larger then specified in the option,
-then the proxy returns a BADPROXYPOLICY status. The proxy sets the value of
+then the proxy returns a BADPROXYPOLICY response code. The proxy sets the value of
 Scope to the actual scope of the source address of the request.
 
-If the request contains a TRUST ANCHOR Option, then the proxy tries to 
+If the request contains a TRUST ANCHOR Option, then the proxy tries to
 fetch the trust anchor XML and p7s files if it does not have them already.
-If fetch one or both fails then the proxy sets the corresponding 
+If fetching one or both fails then the proxy sets the corresponding
 length to zero. It is not clear how long the proxy can cache this information.
 [@RFC7958] Does not describe how long these documents can be cache.
 A simple solution is to take the Expires header in the HTTP reply.
@@ -502,7 +503,7 @@ SHOULD connect to the proxy using Do53 and as remote address either ::1 or
 127.0.0.1. In particular, the stub resolver SHOULD avoid using name
 servers listed in files such as /etc/resolv.conf.
 
-There reason for this is to simply the intergration of local DNS proxies
+There reason for this is to simplify the integration of local DNS proxies
 in existing environments. If the stub resolver ignores /etc/resolv.conf
 then the proxy can use that information to connect to recursive resolvers.
 
@@ -524,7 +525,7 @@ IANA has assigned the following DNS EDNS0 option codes:
      TBD     PROXY SCOPE    Standard   RFC xxxx
      TBD     TRUST ANCHOR   Standard   RFC xxxx
 
-  IANA has assigned the following DNS error code as an early allocation
+  IANA has assigned the following DNS response code as an early allocation
   per [@RFC7120]:
 
      RCODE    Name             Description                   Reference


### PR DESCRIPTION
Hi Philip, just went through the text and I found some nits and typos which are addressed with this PR.

I also have some comments below:
- BADPROXYPOLICY is not introduced (either text or definition) before the protocol specification section where it is first mentioned.
- For the PROXY CONTROL option, should flags on byte 6 only include the allow flags and byte 8 then only the disallow flags? Then there is more space for future transports.
- In the byte representation of the options all optional fields should mention that they can have zero in the length field.
- From a first read I don't fully grasp how the PROXY SCOPE option helps.