### PR TITLE
Philip docs

### DIFF
--- a/API-design.md
+++ b/API-design.md
@@ -141,6 +141,17 @@ trust anchor material is not working, RFC 7958 can be used to fetch
 trust anchor material. this requires a TLS socket (or potentially a TCP
 socket).
 
+## Rust Bindings
+
+Bindings for Rust are important to consider early on for two reasons: Rust is low-level language like C, so it can be a building block for implementations. In addition Rust has language support for asynchronous functions. This makes the Rust version quite different from the C version. Rust tries to have language features with as little overhead as possible. In Rust the basic async mechanisms are:
+
+1. an async function returns a future.
+2. Invoking await on a future blocks the caller until the async function has completed and the value of await is the return value of the function.
+
+In the context of a synchronous function, waiting for an async function to complete blocks the thread. However, if an async function calls await then the async function is suspended and will continue when the called async function has completed.
+
+Calling drop on a future cancels the async function. Note that drop can be called implicitly, so it is important that an async function does not have (conceptual) state.
+
 ## Orchestration. 
 
 Orchestration can be implicit or explicit. Implicit orchestration means that

--- a/API-design.md
+++ b/API-design.md
@@ -1,0 +1,158 @@
+# High level goals
+
+The basic concept of 'Connect By Name' is easy to explain. In terms of the C language, a function with prototype:
+
+```
+int connectbyname(const char *hostname, const char *servname);
+```
+
+that returns a connected TCP socket.
+
+This function can be trivially implemented with calls to 
+getaddrinfo, socket, and connect.
+
+However, we want more functionality than just the basics. Many applications
+need a TLS connection instead of just a TCP socket. With TLS also comes
+the need to support DANE and optionally RFC 9102 (TLS DNSSEC Chain Extension),
+which is experimental.
+
+Instead of waiting for both the DNS 'A' and 'AAAA' queries to complete and
+then connecting to each address in turn, we need to implement 'Happy Eyeballs',
+which uses relatively short timeouts to try IPv6 first, but fall 
+back to IPv4 if that does not succeed fast enough.
+
+At the DNS level, we need to have the option of local DNSSEC validation,
+fetching a trust anchor, plain old DNS on port 53, DNS over TLS, DNS over
+HTTPS. 
+
+At the API level, we need to support event-based applications.
+
+# Specifics of the API
+
+We can separate the API interface from the functionality provide by the API.
+The API interface design involves questions such as how to pass options
+to the API and receive information about the resulting configuration.
+How to deal with the various libraries that implement TLS and
+how to deal with event-based applications.
+
+Starting with
+
+```
+int connectbyname(const char *hostname, const char *servname);
+```
+the first thing that is obviously missing is ability to pass options to
+the call. For example, getaddrinfo has a 'hints' parameter. Getdns uses
+a context and an extensions dict. As a starting point we can assume a
+context parameter. So we get something like this:
+
+```
+int connectbyname(context_T *context, const char *hostname,
+	const char *servname);
+```
+Next, we have the issue of TLS. There are many TLS libraries. One option
+is to define one API call per library where the user selects which one
+should be provided. For example,
+
+```
+SSL *connectbynameOpenSSL(context_T *context, const char *hostname,
+        const char *servname);
+```
+The advantage of this approach is that the client can use all functions of
+the TLS library (for example, to check which ciphers are negotiated).
+
+An alternative approach is to have a generic interface, similar to libevents
+struct bufferevent. This makes the core of the API independent of the
+specific TLS library that is used. For example,
+
+```
+struct bufferevent *connectbynameTLS(context_T *context,
+	const char *hostname, const char *servname);
+```
+Note that we probably need a way to pass library specific configuration
+options before the TLS connection is created and we probably need to get the
+underlying TLS library object as well to perform library specific functions.
+But hopefully, that is something for specialized applications and not the
+common case.
+
+Next, we have the way to make functions asynchronous. The easiest way
+is to add a callback function and a client ref to the parameters and 
+return an API ref that can be used, for example, to cancel the operation.
+For example,
+
+```
+struct bufferevent *connectbynameTLS(context_T *context,
+	const char *hostname, const char *servname, callback_T *callback,
+	ref_T client_ref, ref_T *api_ref);
+```
+Finally, we need a way to specify orchestration. Do we want, or insist on
+DANE. Do we want DoT, etc.
+
+# Functionality
+
+One way to model functionality is as a collection of processes. The actual
+implementation has to be asynchronous. But a collection of processes is easy
+to reason about.
+
+At the heart is the Happy Eyballs process. This process receives a stream of
+DNS replies and produces a stream of connected TCP sockets. Note that
+the process is expected receive at most one reply to an 'A' query and one
+for a 'AAAA'. Similarly, we expect that the consumer of the sockets will
+initially receive one and request more if the ones already delivered don't
+work out.
+
+The TLS process uses the sockets from the Happy Eyeballs process to set up
+a TLS connection. This process optionally receives a DANE reply. If
+RFC 9102 is implemented then during the setup of the TLS connection,
+the process receives a collection of DNS replies that need to be 
+DNSSEC validated.
+
+At the bottom we expect four types of DNS processes. These processes
+receive a series of DNS requests and produce a series of DNS replies.
+The most basic of these DNS processes is Do53. This is the classical,
+UDP-based DNS transport with a fallback to TCP. Typical configuration is
+a collection of addresses, usually obtained from /etc/resolv.conf.
+
+Then there is DoT. The DoT is similar to Do53, in that configuration is
+typically a collection of IP addresses. This results in optimistic encryption.
+Which a name, we can trivially upgrade to full TLS using PKI. DANE would
+pose the issue that we need to perform the DNS queries for DANE before we
+have fully established a DNS process. Note that worst base, DNSSEC valition
+may also generate additonal DNS queries even if RFC 9102 is used.
+
+For DoH we need to have a name. In fact, we need a URL. This means that
+the DoH process likely needs Do53 or DoT to resolve the name. And then
+the TLS process and Happy Eyeballs could be used to establish a TLS socket.
+Note that is different from Do53 and DoT where typical implementations
+support at most three address in /etc/resolv.conf. So we can just try
+all three of them (with suitable timeouts).
+
+The fourth DNS process is a recursive resolver. Configuation information
+the address of the root DNS servers. For now we assume that all communication
+is Do53.
+
+A DNSSEC process receives a stream of DNS queries and produces a stream
+of DNSSEC validated DNS replies. The process receives from a trust-anchor
+process material to validate the root zone. A DNSSEC process needs access to
+a DNS process.
+
+A Trust Anchor process reads trust anchor material from the local filesystem
+and needs recent material from root zone to validate. If the local 
+trust anchor material is not working, RFC 7958 can be used to fetch
+trust anchor material. this requires a TLS socket (or potentially a TCP
+socket).
+
+## Orchestration. 
+
+Orchestration can be implicit or explicit. Implicit orchestration means that
+processes themselves create required processes. For example, the API could
+create a TLS process, which would create a Happy Eyeballs and a DNSSEC 
+process (for DANE). The Happy Eyeballs process would also create a 
+DNSSEC process, etc. Disavantage is that control over the runtime is
+indirect.
+
+With explict orchestration a separate orchestration process creates the
+required processes and connects them. The big question is whether or not
+the orchestration process become too complex to understand. If we need a lot
+of interposing, it may also slow things down.
+
+v0.1 2021-11-05

--- a/API-prototypes.md
+++ b/API-prototypes.md
@@ -1,0 +1,11 @@
+# Prototype Plan
+
+The basic idea is make a series of prototypes with increasing complexity. 
+
+1. A prototype based on getaddrinfo, socket, connect, select and some TLS library like openssl. DNS resolution will be blocking but it should be possible to implement a simple version of Happy Eyeballs. No local DNSSEC validation.
+2. A prototype based on libevent. Libevent has an asynchronous stub resolver and abstracts TLS. So it should be possible to implement Happy Eyeballs without limitations. No local DNSSEC validation.
+3. A prototype based on Getdns and libevent. It is possible to implements Happy Eyeballs. And Getdns provides local DNSSEC validation.
+4. A prototype based on a restructured Getdns that gives the user more control over orchestration.
+
+## Future Work
+The first prototypes assume a simple, stable network environment. In the future we should support (wifi) networks that come and go, switch between wifi and mobile, etc.

--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -338,7 +338,21 @@ specified addresses and use the name for authentication.
 To simplify the encoding of the option, an option with addresses will
 have either IPv4 or IPv6 addresses. If the application wants to specify
 both IPv4 and IPv6 addresses for a certain authentication-domain-name
-then it has to include two options.
+then it has to include two options. 
+
+An application may want to specify a DNS resolver that is reachable 
+through an IPv6 link-local address.
+IPv6 link-local addresses are special in that they require a zone to be
+specified, either explicitly or implicitly. Typically for a link-local
+address that appears as a source or destination address,
+the zone is implicitly the zone of the link the packet travels on.
+For packets that travel between hosts, there is no goed way to explictly
+specify the zone of a link-local address because two different hosts
+do not agree on zone names. However, if the proxy is on the same host
+as the application, then the zone identifier for the link-local address
+can be specified in the Interface field. For this purpose an interface
+name can also be an interface index expressed as a decimal string.
+
 
 When present, Service Parameters specify how to connect. Otherwise it is
 up to the proxy to try various possibilities.

--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -289,7 +289,9 @@ The next flags provide more detailed control over which transports
 should be used or not. For each of 5 different transports
 (Do53, DoT, DoH with ALPN h2, DoH with ALPN h3, DoQ) there is a flag
 to allow (A53,AT,AH2,AH3,AQ) or disallow (D53,DT,DH2,DH3,DQ) the use of the
-transport. There is space to add more transports later.
+transport. There is space to add more transports later. Note that setting
+the A flags and the D flag for a protocol (for example, setting both the
+A53 and the D53 flags) is not allowed and a proxy SHOULD reject such a request.
 
 To future proof applications, there is a single flag DO, that disallows
 transports that are not explicitly listed. With this flag clear,
@@ -297,6 +299,17 @@ the application allows future transports. With the flag set, the
 application has to explicitly list which transports can be used.
 For example, by setting only DO and AT, the application forces the
 use of DoT.
+
+When DO = 0:
+
+* all transports are in the pool of potentially usable transports
+* D53, DT, DH2, DH3 and DQ remove those transports from the pool
+
+When DO = 1:
+
+* no transports are in the pool of potentially usable transports
+* A53, AT, AH2, AH3 and AQ add those transports to the pool
+
 
 Finally, an application can specify its own resolvers or rely on the
 resolvers that are know to the proxy. If ADN Length and Addr Length

--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -10,7 +10,7 @@ name = "Internet-Draft"
 value = "draft-homburg-add-codcp-00"
 stream = "IETF"
 
-date = 2022-05-02T00:00:00Z
+date = 2022-07-11T00:00:00Z
 
 [[author]]
 initials="P.C."

--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -477,7 +477,7 @@ matches the provided policy, then the proxy sets the BADPROXYPOLICY
 response code in the reply. In addition the proxy SHOULD try to find at least
 one connection to a recursive resolver. If the proxy did not find an
 alternative connection to a recursive resolver (also if it didn't try) then
-the proxy includes a PROXY POLICY Option with all flags set to zero,
+the proxy includes a PROXY CONTROL Option with all flags set to zero,
 and with  ADN Length, Addr Length, and SvcParams Length set to zero as well.
 
 If the proxy does have one or more alternative connections to recursive
@@ -521,7 +521,7 @@ IANA has assigned the following DNS EDNS0 option codes:
 
      Value   Name           Status     Reference
     ------- -------------- ---------- -----------
-     TBD     PROXY POLICY   Standard   RFC xxxx
+     TBD     PROXY CONTROL  Standard   RFC xxxx
      TBD     PROXY SCOPE    Standard   RFC xxxx
      TBD     TRUST ANCHOR   Standard   RFC xxxx
 

--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -326,7 +326,7 @@ specified addresses and use the name for authentication.
 
 To simplify the encoding of the option, an option with addresses will
 have either IPv4 or IPv6 addresses. If the application wants to specify
-both IPv4 and IPv6 address for a certain authentication-domain-name
+both IPv4 and IPv6 addresses for a certain authentication-domain-name
 then it has to include two options.
 
 When present, Service Parameters specify how to connect. Otherwise it is
@@ -515,7 +515,7 @@ SHOULD connect to the proxy using Do53 and as remote address either ::1 or
 127.0.0.1. In particular, the stub resolver SHOULD avoid using name
 servers listed in files such as /etc/resolv.conf.
 
-There reason for this is to simplify the integration of local DNS proxies
+The reason for this is to simplify the integration of local DNS proxies
 in existing environments. If the stub resolver ignores /etc/resolv.conf
 then the proxy can use that information to connect to recursive resolvers.
 

--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -7,7 +7,7 @@ workgroup = "ADD"
 [seriesInfo]
 status = "standard"
 name = "Internet-Draft"
-value = "draft-homburg-codcp-00"
+value = "draft-homburg-add-codcp-00"
 stream = "IETF"
 
 date = 2022-05-02T00:00:00Z

--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -23,7 +23,7 @@ organisation = "NLnet Labs"
 
 .# Abstract
 
-The introduction of many new transport portocols for DNS in recent years
+The introduction of many new transport protocols for DNS in recent years
 (DoT, DoH, DoQ)
 significantly increases the complexity of DNS stub
 resolvers that want to support these protocols. A practical way forward
@@ -47,7 +47,7 @@ for example, for large responses, TCP is used, also on port 53.
 
 DoH
 
-: DNS over HTTPS as described in [@RFC8484]. 
+: DNS over HTTPS as described in [@RFC8484].
 
 DoT
 
@@ -79,7 +79,7 @@ consider an interface name.
 
 # Introduction
 
-The introduction of many new transport portocols for DNS in recent years
+The introduction of many new transport protocols for DNS in recent years
 (DoT, DoH, DoQ)
 significantly increases the complexity of DNS stub
 resolvers that want to support these protocols. In addition,
@@ -91,7 +91,7 @@ is to have a DNS client proxy in the host operating system.
 A local proxy may provide some benefit to short-lived applications by
 caching results. In particular if the system uses a so called 'public
 DNS resolver'. In general we assume that the cache is tagged according
-to the source of a reply and the transport it is received on. 
+to the source of a reply and the transport it is received on.
 
 
 This allows
@@ -104,9 +104,9 @@ capabilities and actual transports that are available.
 
 
 With respect to DNSSEC, we assume that an application that needs
-DNSSEC validation, for example, for DANE validation or SSHFP, will 
+DNSSEC validation, for example, for DANE validation or SSHFP, will
 perform the DNSSEC validation within the application itself and does not
-trust the proxy. The proxy can ofcourse do DNSSEC validation as well.
+trust the proxy. The proxy can of course do DNSSEC validation as well.
 Important however, is that an untrusted proxy cannot provide an application
 with a traditional (unsigned) trust anchor.
 
@@ -118,7 +118,7 @@ third level is where the application also specifies which transports
 (Do53, DoT, DoH, DoQ) are allowed to be used. A final transport parameter
 is the outgoing interface that is to be used.
 
-For authentication we can have a mix of PKI and DANE. Options are one of 
+For authentication we can have a mix of PKI and DANE. Options are one of
 the two and not the other, both or one of the two.
 
 A poorly constructed DNS client proxy may forward DNS packets without
@@ -126,9 +126,9 @@ properly handling of EDNS(0) options. To detect and prevent this,
 we introduce an option that limits the connection to host-local, link-local,
 or site-local. The requirement on a conforming DNS client proxy is to
 check where a request comes from and compare this to the option in
-the request (if any). And error is returned if there is a mismatch.
+the request (if any). An error is returned if there is a mismatch.
 
-In a reponse, the proxy reports the interface, resolver, and transport
+In a response, the proxy reports the interface, resolver, and transport
 used.
 
 In the ideal case, the host operating system provides applications with a
@@ -148,7 +148,7 @@ when, and only when, they appear in all capitals, as shown here.
 
 # Description
 
-This document introduces the new EDNS(0) options, and one new status code.
+This document introduces the new EDNS(0) options, and one new response code.
 This first option, called PROXY CONTROL Option, specifies which transports
 a proxy should use to connect to a recursive resolver.
 
@@ -280,9 +280,9 @@ client proxy. The U flag specifies no encryption, the UA flag, at
 least unauthenticated encryption and the A flag require authenticated
 encryptions. With the U, UA, and A flags clear, an effort is made to
 reach authenticated encryption, if that fails unauthenticated encryption
-and if that fails, fall back to an unencryption transport.
+and if that fails, fall back to an unencrypted transport.
 The P and D flags allow the application to require
-a specfic authentication mechanism (PKI or DANE). When both flags are set,
+a specific authentication mechanism (PKI or DANE). When both flags are set,
 PKI and DANE are required together. If no flags are set, are least one of
 the two has to succeed if authenticated encryption is required.
 
@@ -293,26 +293,26 @@ to allow (A53,AT,AH2,AH3,AQ) or disallow (D53,DT,DH2,DH3,DQ) the use of the
 transport. There is space to add more transports later.
 
 To future proof applications, there is a single flag DO, that disallows
-transports that are not explicitly listed. Which this flag clear,
+transports that are not explicitly listed. With this flag clear,
 the application allows future transports. With the flag set, the
 application has to explicitly list which transports can be used.
 For example, by setting only DO and AT, the application forces the
 use of DoT.
 
-Finally, an application can specify it's own resolvers or rely on the
+Finally, an application can specify its own resolvers or rely on the
 resolvers that are know to the proxy. If ADN Length and Addr Length
 are both zero, then the application requests to resolvers known to
 the proxy. [Note: it is unclear at the moment what to do with any
 Service Parameters]
 
 If the application specifies only an authentication-domain-name then the
-proxy is expect to resolve the name to addresses. If only addresses
+proxy is expected to resolve the name to addresses. If only addresses
 are specified then the proxy assumes that no name is known (though
 a PKI certificate may include an address literal in the subjectAltName).
 If both a name and address are specified then the proxy will use the
 specified addresses and use the name for authentication.
 
-To simplify the encoding of the option, an option with addresses with
+To simplify the encoding of the option, an option with addresses will
 have either IPv4 or IPv6 addresses. If the application wants to specify
 both IPv4 and IPv6 address for a certain authentication-domain-name
 then it has to include two options.
@@ -339,11 +339,11 @@ OPTION-CODE
 
 OPTION-LENGTH
 
-: Lenght of this option excluding the OPTION-CODE and OPTION-LENGTH fields
+: Length of this option excluding the OPTION-CODE and OPTION-LENGTH fields
 
 Scope
 
-: Scope of the source address of a request. Scope can have the following 
+: Scope of the source address of a request. Scope can have the following
 values:
 
      Value | Scope
@@ -354,8 +354,8 @@ values:
      3     | Site local
      4     | Global
 
-The purpose of this option is deal with badly implemented proxy that forward
-DNS traffic without first removing any EDNS(0) options. The option request
+The purpose of this option is to deal with badly implemented proxies that forward
+DNS traffic without first removing any EDNS(0) options. The option requests
 the DNS proxy that processes the option to report the scope of the source
 address. The application can specify that the connection between the stub
 resolver and the proxy should have, for example, at most host local scope.
@@ -407,19 +407,20 @@ ANCHORS-P7S
 
 This option provides DNSSEC trust anchors as described in [@RFC7958].
 
+
 # Protocol Specification
 
 # Client Processing
 
 A stub resolver that wishes to use the PROXY CONTROL Option includes the
-option in all outgoing DNS requests that require privacy. The option 
+option in all outgoing DNS requests that require privacy. The option
 should be initialized according to the needs of the application.
 In addition the PROXY SCOPE Option can be added. In requests, the Scope
 field is set to largest scope that the application can accept.
 
 If the stub resolver receives a reply without a PROXY CONTROL Option
 included in the reply, then stub resolver has to assume that traffic will
-have Do%3 levels of privacy.  Similarly, a lack of a PROXY SCOPE Option 
+have Do53 levels of privacy.  Similarly, a lack of a PROXY SCOPE Option
 implies a global scope.
 
 If the stub resolver receives a BADPROXYPOLICY error then the proxy was
@@ -428,18 +429,18 @@ modifies the options to show what it can do.
 
 ## Probing
 
-In cases where the stub resolvers expects a local DNS proxy, or where the
-stub resolver has (a limited) fall back to more private transports, or 
+In cases where the stub resolver expects a local DNS proxy, or where the
+stub resolver has (a limited) fall back to more private transports, or
 when the security policy of the application is such that is better to fail
-then the send queries over Do53, the stub resolver first sends probing
-query to verify that the proxy supports the PROXY CONTROL and 
+than send queries over Do53, the stub resolver first sends a probing
+query to verify that the proxy supports the PROXY CONTROL and
 PROXY SCOPE options.
 
-This request queries "resolver.arpa". The proxy MUST implement this as a 
+This request queries "resolver.arpa". The proxy MUST implement this as a
 Special Use Domain Name. The actual response is not important. The
 important part is that the proxy returns PROXY CONTROL and PROXY SCOPE
-options as described in the this documents and optionally sets
-the result to BADPROXYPOLICY specified policy.
+options as described in this document and optionally sets
+the response code to BADPROXYPOLICY specified policy.
 
 ## Trust Anchor
 
@@ -452,7 +453,7 @@ obtain the trust anchor XML file and the signature over the trust anchor.
 For this reason, it makes sense to let the proxy cache this information.
 
 If the local operating system does not provide a DNSSEC trust anchor, then
-the application can ask the proxy. The stub resolver adds the TRUST ANCHOR 
+the application can ask the proxy. The stub resolver adds the TRUST ANCHOR
 Option with ANCHORS-XML-LENGTH and ANCHORS-P7S-LENGTH. If the proxy
 returns both an ANCHORS-XML and an ANCHORS-P7S, then the application verifies
 the trust anchor using the trust anchor certificate (which needs to come
@@ -463,34 +464,34 @@ with the application).
 Proxies are encouraged to cache options that appear in requests under the
 assumption that a stub resolver will send multiple requests. If a proxy
 caches DNS responses then the proxy MUST tag cached responses with the
-properties of the DNS transport. When responding the later requests,
-then proxy returns a cached entry only if the parameters of the DNS transport
+properties of the DNS transport. When responding to later requests,
+the proxy returns a cached entry only if the parameters of the DNS transport
 match what is specified in the request.
 
 When a proxy receives a new set of requirements, the proxy compiles a list of
-addresses to connect to and per address a list of transports to try.
+addresses to connect to and a list of transports to try per address.
 The proxy SHOULD prefer more private transports over less private ones.
 
-If the proxy cannot obtain a connect to a recursive resolver in a way that
+If the proxy cannot obtain a connection to a recursive resolver in a way that
 matches the provided policy, then the proxy sets the BADPROXYPOLICY
-status in the reply. In addition the proxy SHOULD try to find at least
+response code in the reply. In addition the proxy SHOULD try to find at least
 one connection to a recursive resolver. If the proxy did not find an
-alternative connection to recursive resolver (also if it didn't try) then
-the proxy include a PROXY POLICY Option with all flags set to zero,
+alternative connection to a recursive resolver (also if it didn't try) then
+the proxy includes a PROXY POLICY Option with all flags set to zero,
 and with  ADN Length, Addr Length, and SvcParams Length set to zero as well.
 
-If the proxy does have one or more alternative connections to resursive
+If the proxy does have one or more alternative connections to recursive
 resolvers then the proxy generates options with the properties of those
 connection, with a maximum of three connections.
 
 If the proxy finds a PROXY SCOPE Option, then it calculates the scope from
 the source address. If the scope is larger then specified in the option,
-then the proxy returns a BADPROXYPOLICY status. The proxy sets the value of
+then the proxy returns a BADPROXYPOLICY response code. The proxy sets the value of
 Scope to the actual scope of the source address of the request.
 
-If the request contains a TRUST ANCHOR Option, then the proxy tries to 
+If the request contains a TRUST ANCHOR Option, then the proxy tries to
 fetch the trust anchor XML and p7s files if it does not have them already.
-If fetch one or both fails then the proxy sets the corresponding 
+If fetching one or both fails then the proxy sets the corresponding
 length to zero. It is not clear how long the proxy can cache this information.
 [@RFC7958] Does not describe how long these documents can be cache.
 A simple solution is to take the Expires header in the HTTP reply.
@@ -502,7 +503,7 @@ SHOULD connect to the proxy using Do53 and as remote address either ::1 or
 127.0.0.1. In particular, the stub resolver SHOULD avoid using name
 servers listed in files such as /etc/resolv.conf.
 
-There reason for this is to simply the intergration of local DNS proxies
+There reason for this is to simplify the integration of local DNS proxies
 in existing environments. If the stub resolver ignores /etc/resolv.conf
 then the proxy can use that information to connect to recursive resolvers.
 
@@ -524,7 +525,7 @@ IANA has assigned the following DNS EDNS0 option codes:
      TBD     PROXY SCOPE    Standard   RFC xxxx
      TBD     TRUST ANCHOR   Standard   RFC xxxx
 
-  IANA has assigned the following DNS error code as an early allocation
+  IANA has assigned the following DNS response code as an early allocation
   per [@RFC7120]:
 
      RCODE    Name             Description                   Reference

--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -532,4 +532,8 @@ IANA has assigned the following DNS EDNS0 option codes:
     -------- ---------------- ----------------------------- -----------
      TBD      BADPROXYPOLICY   Unable to conform to policy   RFC xxxx
 
+# Acknowledgements
+
+Many thanks to Yorgos Thessalonikefs and Willem Toorop for their feedback.
+
 {backmatter}

--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -41,7 +41,7 @@ capabilities and actual transports that are available.
 
 Do53
 
-: The original, plain text DNS transport as described in [@RFC1035].
+: The original, plain text DNS transport as described in [@RFC1034;@RFC1035].
 Typically, UDP is used, with the DNS server listening on port 53. Sometimes,
 for example, for large responses, TCP is used, also on port 53.
 
@@ -272,7 +272,7 @@ Domain Name Length
 Domain Name
 
 : domain name for authentication or resolving IP addresses. The domain name
-is encoding in uncompressed DNS wire format.
+is encoded in uncompressed DNS wire format.
 
 SvcParams Length
 
@@ -367,7 +367,7 @@ should be used or not. For each of 5 different transports
 (Do53, DoT, DoH with ALPN h2, DoH with ALPN h3, DoQ) there is a flag
 to allow (A53,AT,AH2,AH3,AQ) or disallow (D53,DT,DH2,DH3,DQ) the use of the
 transport. There is space to add more transports later. Note that setting
-the A flags and the D flag for a protocol (for example, setting both the
+the A flag and the D flag for a protocol (for example, setting both the
 A53 and the D53 flags) is not allowed and a proxy SHOULD reject such a request.
 
 To future proof applications, there is a single flag DD, that by default
@@ -381,13 +381,14 @@ use of DoT.
 When DD = 0:
 
 * all transports are in the pool of potentially usable transports
-* D53, DT, DH2, DH3 and DQ remove those transports from the pool
+* D53, DT, DH2, DH3 and DQ remove those transports from the pool.
+* The values of A53, AT, AH2, AH3 and AQ are irrelevant
 
 When DD = 1:
 
 * no transports are in the pool of potentially usable transports
 * A53, AT, AH2, AH3 and AQ add those transports to the pool
-
+* The values of D53, DT, DH2, DH3 and DQ are irrelevant
 
 Finally, an application can specify its own resolvers or rely on the
 resolvers that are known to the proxy. If ADN Length and Addr Length
@@ -429,6 +430,11 @@ can only be specified using the addresses field in the PROXY CONTROL Option.
 Associated with this option is a new error, BADPROXYPOLICY. When
 a proxy cannot meet the requirements in a PROXY CONTROL Option or the
 option is malformed, it returns this error.
+
+If the proxy returns a BADPROXYPOLICY error, the proxy MAY include
+a PROXY CONTROL Option that lists what the proxy can do. For example,
+if authenticated encryption is not possible, but unauthenticated is,
+then the proxy may include an option that has the UA bit set.
 
 # PROXY SCOPE OPTION
 

--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -111,7 +111,7 @@ Important however, is that an untrusted proxy cannot provide an application
 with a traditional (unsigned) trust anchor.
 
 For the transport configuration we expect three levels of details. The
-first is a choice between anythings goes, optimistic encryption and
+first is a choice between anythings goes, unauthenticated encryption and
 authenticated encryption. The second level is where the application also
 specifies the names and/or IP addresses of upstream resolvers. The
 third level is where the application also specifies which transports
@@ -167,7 +167,7 @@ trust anchor signed by IANA.
       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
    2: |                         OPTION-LENGTH                         |
       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-   4: | U | O | A | P | D |DO |                     Z                 |
+   4: | U |UA | A | P | D |DO |                     Z                 |
       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
    6: |A53|D53|AT |DT |AH2|DH2|AH3|DH3|AQ |DQ |         Z             |
       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -204,9 +204,9 @@ U
 
 : force the use of unencrypted communication (Do53)
 
-O
+UA
 
-: use at least optimistic encryption
+: require unauthenticated encryption
 
 A
 
@@ -274,12 +274,17 @@ Interface Name
 : name of outgoing interface for transport connections
 
 This option is designed to give control over what level of detail it
-wants to specify. The first 5 flags (U, O, A, P, and D) give generate
+wants to specify. The first 5 flags (U, UA, A, P, and D) give generate
 requirements for properties of DNS transports that are used by the
-client proxy. The U flag specifies no encryption, the O flag, at
-least optimistic encryption and the A flag require authenticated
-encryptions. The P and D flags allow the application to require
-a specfic authentication mechanism (PKI or DANE).
+client proxy. The U flag specifies no encryption, the UA flag, at
+least unauthenticated encryption and the A flag require authenticated
+encryptions. With the U, UA, and A flags clear, an effort is made to
+reach authenticated encryption, if that fails unauthenticated encryption
+and if that fails, fall back to an unencryption transport.
+The P and D flags allow the application to require
+a specfic authentication mechanism (PKI or DANE). When both flags are set,
+PKI and DANE are required together. If no flags are set, are least one of
+the two has to succeed if authenticated encryption is required.
 
 The next flags provide more detailed control over which transports
 should be used or not. For each of 5 different transports

--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -342,6 +342,10 @@ then it has to include two options.
 When present, Service Parameters specify how to connect. Otherwise it is
 up to the proxy to try various possibilities.
 
+Associated with this option is a new error, BADPROXYPOLICY. When
+a proxy cannot meet the requirement in a PROXY CONTROL option, it returns
+this error along with a PROXY CONTROL option that lists what it can do.
+
 # PROXY SCOPE OPTION
 
 ~~~

--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -111,8 +111,7 @@ Important however, is that an untrusted proxy cannot provide an application
 with a traditional (unsigned) trust anchor.
 
 For the transport configuration we expect three levels of details. The
-first is a choice between anythings goes, unauthenticated encryption and
-authenticated encryption. The second level is where the application also
+first is a choice between requiring authenticated encryption, also allowing unauthenticated encryption or doing opportunistic encryption on an best effort basis. The second level is where the application also
 specifies the names and/or IP addresses of upstream resolvers. The
 third level is where the application also specifies which transports
 (Do53, DoT, DoH, DoQ) are allowed to be used. A final transport parameter

--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -1,0 +1,529 @@
+%%%
+title = "Control Options For DNS Client Proxies"
+abbrev = "codcp"
+area = "Internet"
+workgroup = "ADD"
+
+[seriesInfo]
+status = "standard"
+name = "Internet-Draft"
+value = "draft-homburg-codcp-00"
+stream = "IETF"
+
+date = 2022-05-02T00:00:00Z
+
+[[author]]
+initials="P.C."
+surname="Homburg"
+fullname="Philip Homburg"
+organisation = "NLnet Labs"
+  [author.address]
+  email = "philip@nlnetlabs.nl"
+%%%
+
+.# Abstract
+
+The introduction of many new transport portocols for DNS in recent years
+(DoT, DoH, DoQ)
+significantly increases the complexity of DNS stub
+resolvers that want to support these protocols. A practical way forward
+is to have a DNS client proxy in the host operating system. This allows
+applications to communicate using Do53 and still get the privacy
+benefit from using more secure protocols over the internet. However,
+such a setup leaves the application with no control over which transport
+the proxy uses. This document introduces EDNS(0) options that allow a
+stub resolver to request certain transport and allow the proxy to report
+capabilities and actual transports that are available.
+
+{mainmatter}
+
+# Definitions
+
+Do53
+
+: The original, plain text DNS transport as described in [@RFC1035].
+Typically, UDP is used, with the DNS server listening on port 53. Sometimes,
+for example, for large responses, TCP is used, also on port 53.
+
+DoH
+
+: DNS over HTTPS as described in [@RFC8484]. 
+
+DoT
+
+: DNS over TLS as described in [@RFC7858]
+
+DoQ
+
+: DNS over QUIC ([@RFC9000]) as described in [I-D.ietf-dprive-dnsoquic],
+not to be confused with DNS over HTTP/3 which also uses QUIC
+
+EDNS(0) Option
+
+: An option as described in [@RFC6891]
+
+h2
+
+: This TLS ALPN identifies HTTP/2 as described in [@RFC7540]
+
+h3
+
+: This TLS ALPN identifies HTTP/3, which is HTTP over QUIC and
+is described in I.D.ietf-quic-http (expired draft)
+
+Interface Name
+
+: A name that identifies a network interface as described in [@RFC3493].
+In addition, an interface index converted to a decimal number is also
+consider an interface name.
+
+# Introduction
+
+The introduction of many new transport portocols for DNS in recent years
+(DoT, DoH, DoQ)
+significantly increases the complexity of DNS stub
+resolvers that want to support these protocols. In addition,
+for short-lived applications, the overhead of setting a DoH connection
+is quite high if the application only needs to send a few DNS requests.
+
+A practical way forward
+is to have a DNS client proxy in the host operating system.
+A local proxy may provide some benefit to short-lived applications by
+caching results. In particular if the system uses a so called 'public
+DNS resolver'. In general we assume that the cache is tagged according
+to the source of a reply and the transport it is received on. 
+
+
+This allows
+applications to communicate using Do53 and still get the privacy
+benefits from using more secure protocols over the internet. However,
+such a setup leaves the application with no control over which transport
+the proxy uses. This document introduces EDNS(0) options that allow a
+stub resolver to request certain transports and allow the proxy to report
+capabilities and actual transports that are available.
+
+
+With respect to DNSSEC, we assume that an application that needs
+DNSSEC validation, for example, for DANE validation or SSHFP, will 
+perform the DNSSEC validation within the application itself and does not
+trust the proxy. The proxy can ofcourse do DNSSEC validation as well.
+Important however, is that an untrusted proxy cannot provide an application
+with a traditional (unsigned) trust anchor.
+
+For the transport configuration we expect three levels of details. The
+first is a choice between anythings goes, optimistic encryption and
+authenticated encryption. The second level is where the application also
+specifies the names and/or IP addresses of upstream resolvers. The
+third level is where the application also specifies which transports
+(Do53, DoT, DoH, DoQ) are allowed to be used. A final transport parameter
+is the outgoing interface that is to be used.
+
+For authentication we can have a mix of PKI and DANE. Options are one of 
+the two and not the other, both or one of the two.
+
+A poorly constructed DNS client proxy may forward DNS packets without
+properly handling of EDNS(0) options. To detect and prevent this,
+we introduce an option that limits the connection to host-local, link-local,
+or site-local. The requirement on a conforming DNS client proxy is to
+check where a request comes from and compare this to the option in
+the request (if any). And error is returned if there is a mismatch.
+
+In a reponse, the proxy reports the interface, resolver, and transport
+used.
+
+In the ideal case, the host operating system provides applications with a
+secure way to access a DNSSEC trust anchor that is maintained according to
+[@RFC5011]. However in situations where this is not the case, an application
+can fall back to [@RFC7958]. However, for short lived processes, there is
+considerable overhead in issuing to HTTP(S) requests to data.iana.org to
+obtain the trust anchor XML file and the signature over the trust anchor.
+For this reason, it makes sense to let the proxy cache this information.
+
+# Key Words
+
+The key words "**MUST**", "**MUST NOT**", "**REQUIRED**", "**SHALL**", "**SHALL NOT**",
+"**SHOULD**", "**SHOULD NOT**", "**RECOMMENDED**", "**NOT RECOMMENDED**", "**MAY**", and
+"**OPTIONAL**" in this document are to be interpreted as described in BCP 14 [@!RFC2119] [@!RFC8174]
+when, and only when, they appear in all capitals, as shown here.
+
+# Description
+
+This document introduces the new EDNS(0) options, and one new status code.
+This first option, called PROXY CONTROL Option, specifies which transports
+a proxy should use to connect to a recursive resolver.
+
+The second option, called PROXY SCOPE Option, controls the IP address scope
+of the connection between the application's stub resolver and the proxy.
+
+Finally, the TRUST ANCHOR Option, provides the application with a DNSSEC
+trust anchor signed by IANA.
+
+
+# PROXY CONTROL OPTION
+
+~~~
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   0: |                          OPTION-CODE                          |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   2: |                         OPTION-LENGTH                         |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   4: | U | O | A | P | D |DO |                     Z                 |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   6: |A53|D53|AT |DT |AH2|DH2|AH3|DH3|AQ |DQ |         Z             |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   8: |         Addr Type             |         Addr Length           |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-|
+      ~                IPv4 or IPv6-address(es)                       ~
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+      |  Domain Name Length           |                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
+      ~                   Domain Name                                 ~
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |          SvcParams Length     |                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
+      ~                 SvcParams                                     ~
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |     Interface Name Length     |                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
+      ~                 Interface Name                                ~
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+~~~
+
+where
+
+{newline="true"}
+OPTION-CODE
+
+: To be decided
+
+OPTION-LENGTH
+
+: Lenght of this option excluding the OPTION-CODE and OPTION-LENGTH fields
+
+U
+
+: force the use of unencrypted communication (Do53)
+
+O
+
+: use at least optimistic encryption
+
+A
+
+: require authenticated encryption
+
+P
+
+: authenticate using a PKI certificate
+
+D
+
+: authenticate using DANE
+
+DO
+
+: disallow other transports (transports that are not explicitly listed)
+
+A53,AT,AH2,AH3,AQ
+
+: allow respectively Do53, DoT, DoH H2, DoH H3, DoQ
+
+D53,DT,DH2,DH3,DQ
+
+: disallow respectively Do53, DoT, DoH H2, DoH H3, DoQ
+
+Z
+
+: reserved, MUST be zero when sending, MUST be ignored when received
+
+Addr Type
+
+: Type of addresses, IPv4 or IPv6
+
+Addr Length
+
+: length of the addresses in octets. Must be a multiple of 4 for IPv4 and
+a multiple of 16 for IPv6
+
+IPv4 or IPv6-address(es)
+
+: list of IPv4 or IPv6 addresses
+
+Domain Name Length
+
+: length of Domain Name. Zero if there is no Domain Name
+
+Domain Name
+
+: domain name for authentication or resolving IP addresses
+
+SvcParams Length
+
+: length of SvcParams
+
+SvcParams
+
+: Service parameters
+
+Interface Name Length
+
+: length of Interface Name
+
+Interface Name
+
+: name of outgoing interface for transport connections
+
+This option is designed to give control over what level of detail it
+wants to specify. The first 5 flags (U, O, A, P, and D) give generate
+requirements for properties of DNS transports that are used by the
+client proxy. The U flag specifies no encryption, the O flag, at
+least optimistic encryption and the A flag require authenticated
+encryptions. The P and D flags allow the application to require
+a specfic authentication mechanism (PKI or DANE).
+
+The next flags provide more detailed control over which transports
+should be used or not. For each of 5 different transports
+(Do53, DoT, DoH with ALPN h2, DoH with ALPN h3, DoQ) there is a flag
+to allow (A53,AT,AH2,AH3,AQ) or disallow (D53,DT,DH2,DH3,DQ) the use of the
+transport. There is space to add more transports later.
+
+To future proof applications, there is a single flag DO, that disallows
+transports that are not explicitly listed. Which this flag clear,
+the application allows future transports. With the flag set, the
+application has to explicitly list which transports can be used.
+For example, by setting only DO and AT, the application forces the
+use of DoT.
+
+Finally, an application can specify it's own resolvers or rely on the
+resolvers that are know to the proxy. If ADN Length and Addr Length
+are both zero, then the application requests to resolvers known to
+the proxy. [Note: it is unclear at the moment what to do with any
+Service Parameters]
+
+If the application specifies only an authentication-domain-name then the
+proxy is expect to resolve the name to addresses. If only addresses
+are specified then the proxy assumes that no name is known (though
+a PKI certificate may include an address literal in the subjectAltName).
+If both a name and address are specified then the proxy will use the
+specified addresses and use the name for authentication.
+
+To simplify the encoding of the option, an option with addresses with
+have either IPv4 or IPv6 addresses. If the application wants to specify
+both IPv4 and IPv6 address for a certain authentication-domain-name
+then it has to include two options.
+
+When present, Service Parameters specify how to connect. Otherwise it is
+up to the proxy to try various possibilities.
+
+# PROXY SCOPE OPTION
+
+~~~
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   0: |                          OPTION-CODE                          |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   2: |                         OPTION-LENGTH                         |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   4: |                          Scope                                |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+~~~
+
+{newline="true"}
+OPTION-CODE
+
+: To be decided
+
+OPTION-LENGTH
+
+: Lenght of this option excluding the OPTION-CODE and OPTION-LENGTH fields
+
+Scope
+
+: Scope of the source address of a request. Scope can have the following 
+values:
+
+     Value | Scope
+    -------|-------
+     0     | Undefined
+     1     | Host local
+     2     | Link local
+     3     | Site local
+     4     | Global
+
+The purpose of this option is deal with badly implemented proxy that forward
+DNS traffic without first removing any EDNS(0) options. The option request
+the DNS proxy that processes the option to report the scope of the source
+address. The application can specify that the connection between the stub
+resolver and the proxy should have, for example, at most host local scope.
+
+# TRUST ANCHOR OPTION
+
+~~~
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   0: |                          OPTION-CODE                          |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   2: |                         OPTION-LENGTH                         |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   4: |             ANCHORS-XML-LENGTH                                |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   6: ~             ANCHORS-XML                                       ~
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   4: |             ANCHORS-P7S-LENGTH                                |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   6: ~             ANCHORS-P7S                                       ~
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+~~~
+
+where
+
+{newline="true"}
+OPTION-CODE
+
+: To be decided
+
+OPTION-LENGTH
+
+: Lenght of this option excluding the OPTION-CODE and OPTION-LENGTH fields
+
+ANCHORS-XML-LENGTH
+
+: Length of ANCHORS-XML in network byte order
+
+ANCHORS-XML
+
+: Trust anchors in XML format
+
+ANCHORS-P7S-LENGTH
+
+: Length of ANCHORS-P7S in network byte order
+
+ANCHORS-P7S
+
+: Signature in p7s format
+
+This option provides DNSSEC trust anchors as described in [@RFC7958].
+
+# Protocol Specification
+
+# Client Processing
+
+A stub resolver that wishes to use the PROXY CONTROL Option includes the
+option in all outgoing DNS requests that require privacy. The option 
+should be initialized according to the needs of the application.
+In addition the PROXY SCOPE Option can be added. In requests, the Scope
+field is set to largest scope that the application can accept.
+
+If the stub resolver receives a reply without a PROXY CONTROL Option
+included in the reply, then stub resolver has to assume that traffic will
+have Do%3 levels of privacy.  Similarly, a lack of a PROXY SCOPE Option 
+implies a global scope.
+
+If the stub resolver receives a BADPROXYPOLICY error then the proxy was
+unable to meet the requirements of the option(s). In the reply, the proxy
+modifies the options to show what it can do.
+
+## Probing
+
+In cases where the stub resolvers expects a local DNS proxy, or where the
+stub resolver has (a limited) fall back to more private transports, or 
+when the security policy of the application is such that is better to fail
+then the send queries over Do53, the stub resolver first sends probing
+query to verify that the proxy supports the PROXY CONTROL and 
+PROXY SCOPE options.
+
+This request queries "resolver.arpa". The proxy MUST implement this as a 
+Special Use Domain Name. The actual response is not important. The
+important part is that the proxy returns PROXY CONTROL and PROXY SCOPE
+options as described in the this documents and optionally sets
+the result to BADPROXYPOLICY specified policy.
+
+## Trust Anchor
+
+In the ideal case, the host operating system provides applications with a
+secure way to access a DNSSEC trust anchor that is maintained according to
+[@RFC5011]. However in situations where this is not the case, an application
+can fall back to [@RFC7958]. However, for short lived processes, there is
+considerable overhead in issuing to HTTP(S) requests to data.iana.org to
+obtain the trust anchor XML file and the signature over the trust anchor.
+For this reason, it makes sense to let the proxy cache this information.
+
+If the local operating system does not provide a DNSSEC trust anchor, then
+the application can ask the proxy. The stub resolver adds the TRUST ANCHOR 
+Option with ANCHORS-XML-LENGTH and ANCHORS-P7S-LENGTH. If the proxy
+returns both an ANCHORS-XML and an ANCHORS-P7S, then the application verifies
+the trust anchor using the trust anchor certificate (which needs to come
+with the application).
+
+# Server Processing
+
+Proxies are encouraged to cache options that appear in requests under the
+assumption that a stub resolver will send multiple requests. If a proxy
+caches DNS responses then the proxy MUST tag cached responses with the
+properties of the DNS transport. When responding the later requests,
+then proxy returns a cached entry only if the parameters of the DNS transport
+match what is specified in the request.
+
+When a proxy receives a new set of requirements, the proxy compiles a list of
+addresses to connect to and per address a list of transports to try.
+The proxy SHOULD prefer more private transports over less private ones.
+
+If the proxy cannot obtain a connect to a recursive resolver in a way that
+matches the provided policy, then the proxy sets the BADPROXYPOLICY
+status in the reply. In addition the proxy SHOULD try to find at least
+one connection to a recursive resolver. If the proxy did not find an
+alternative connection to recursive resolver (also if it didn't try) then
+the proxy include a PROXY POLICY Option with all flags set to zero,
+and with  ADN Length, Addr Length, and SvcParams Length set to zero as well.
+
+If the proxy does have one or more alternative connections to resursive
+resolvers then the proxy generates options with the properties of those
+connection, with a maximum of three connections.
+
+If the proxy finds a PROXY SCOPE Option, then it calculates the scope from
+the source address. If the scope is larger then specified in the option,
+then the proxy returns a BADPROXYPOLICY status. The proxy sets the value of
+Scope to the actual scope of the source address of the request.
+
+If the request contains a TRUST ANCHOR Option, then the proxy tries to 
+fetch the trust anchor XML and p7s files if it does not have them already.
+If fetch one or both fails then the proxy sets the corresponding 
+length to zero. It is not clear how long the proxy can cache this information.
+[@RFC7958] Does not describe how long these documents can be cache.
+A simple solution is to take the Expires header in the HTTP reply.
+
+# Connection Between Stub Resolver And Proxy
+
+Absent other configuration, a stub resolver that implements this standard
+SHOULD connect to the proxy using Do53 and as remote address either ::1 or
+127.0.0.1. In particular, the stub resolver SHOULD avoid using name
+servers listed in files such as /etc/resolv.conf.
+
+There reason for this is to simply the intergration of local DNS proxies
+in existing environments. If the stub resolver ignores /etc/resolv.conf
+then the proxy can use that information to connect to recursive resolvers.
+
+If no DNS server is responding to queries sent using Do53 to ::1 and 127.0.0.1,
+or if the response indicates that this standard is not supported, then
+the stub resolver MAY fall back to traditional configuration methods, such
+as /etc/resolv.conf. However, in that case the stub resolver MUST make
+sure that doing so does not violate the policy set by the application.
+
+# Security Considerations
+
+# IANA Considerations
+
+IANA has assigned the following DNS EDNS0 option codes:
+
+     Value   Name           Status     Reference
+    ------- -------------- ---------- -----------
+     TBD     PROXY POLICY   Standard   RFC xxxx
+     TBD     PROXY SCOPE    Standard   RFC xxxx
+     TBD     TRUST ANCHOR   Standard   RFC xxxx
+
+  IANA has assigned the following DNS error code as an early allocation
+  per [@RFC7120]:
+
+     RCODE    Name             Description                   Reference
+    -------- ---------------- ----------------------------- -----------
+     TBD      BADPROXYPOLICY   Unable to conform to policy   RFC xxxx
+
+{backmatter}

--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -120,15 +120,25 @@ is the outgoing interface that is to be used.
 For authentication we can have a mix of PKI and DANE. Options are one of
 the two and not the other, both or one of the two.
 
-A poorly constructed DNS client proxy may forward DNS packets without
-properly handling of EDNS(0) options. To detect and prevent this,
-we introduce an option that limits the connection to host-local, link-local,
-or site-local. The requirement on a conforming DNS client proxy is to
-check where a request comes from and compare this to the option in
-the request (if any). An error is returned if there is a mismatch.
-
 In a response, the proxy reports the interface, resolver, and transport
 used.
+
+As described in [@RFC5625, Section 3] of [@RFC5625], some simple DNS proxies
+may just forward DNS packets without handling of EDNS(0) options.
+So what could happen is that an application sends a privacy sensitive
+request to local proxy,
+expecting the proxy upstream connection to be encrypted. However, a simple
+proxy may just forward the request unencrypted to another proxy, for exmaple,
+one in a CPE that does implement the protocol described in this document. So
+what could happen is that the request travels unencrypted over a local lan,
+or if proxies deeper in the network support this protocol, even further
+without the application noticing that something is wrong.
+
+To handle this case, we introduce an option that limits the connection between
+the stub resolver and the proxy to host-local, link-local, or site-local. The
+requirement on a conforming DNS client proxy is to
+check where a request comes from and compare this to the option in
+the request (if any). An error is returned if there is a mismatch.
 
 In the ideal case, the host operating system provides applications with a
 secure way to access a DNSSEC trust anchor that is maintained according to

--- a/notes/dns-client-proxy.md
+++ b/notes/dns-client-proxy.md
@@ -252,7 +252,8 @@ Addr Type
 Addr Length
 
 : length of the addresses in octets. Must be a multiple of 4 for IPv4 and
-a multiple of 16 for IPv6
+a multiple of 16 for IPv6. This field can be zero if no addresses are
+specified.
 
 IPv4 or IPv6-address(es)
 
@@ -268,7 +269,7 @@ Domain Name
 
 SvcParams Length
 
-: length of SvcParams
+: length of SvcParams. Zero if there are no service parameters specified.
 
 SvcParams
 
@@ -276,7 +277,7 @@ SvcParams
 
 Interface Name Length
 
-: length of Interface Name
+: length of Interface Name. Zero if no interface is specified.
 
 Interface Name
 

--- a/notes/dns-client-proxy.txt
+++ b/notes/dns-client-proxy.txt
@@ -70,19 +70,19 @@ Table of Contents
    2.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
    3.  Key Words . . . . . . . . . . . . . . . . . . . . . . . . . .   4
    4.  Description . . . . . . . . . . . . . . . . . . . . . . . . .   4
-   5.  PROXY CONTROL OPTION  . . . . . . . . . . . . . . . . . . . .   4
+   5.  PROXY CONTROL OPTION  . . . . . . . . . . . . . . . . . . . .   5
    6.  PROXY SCOPE OPTION  . . . . . . . . . . . . . . . . . . . . .   8
    7.  TRUST ANCHOR OPTION . . . . . . . . . . . . . . . . . . . . .   9
-   8.  Protocol Specification  . . . . . . . . . . . . . . . . . . .   9
+   8.  Protocol Specification  . . . . . . . . . . . . . . . . . . .  10
    9.  Client Processing . . . . . . . . . . . . . . . . . . . . . .  10
      9.1.  Probing . . . . . . . . . . . . . . . . . . . . . . . . .  10
-     9.2.  Trust Anchor  . . . . . . . . . . . . . . . . . . . . . .  10
+     9.2.  Trust Anchor  . . . . . . . . . . . . . . . . . . . . . .  11
    10. Server Processing . . . . . . . . . . . . . . . . . . . . . .  11
    11. Connection Between Stub Resolver And Proxy  . . . . . . . . .  12
    12. Security Considerations . . . . . . . . . . . . . . . . . . .  12
    13. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  12
-   14. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  12
-   15. Normative References  . . . . . . . . . . . . . . . . . . . .  12
+   14. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  13
+   15. Normative References  . . . . . . . . . . . . . . . . . . . .  13
    16. Informative References  . . . . . . . . . . . . . . . . . . .  13
    Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  14
 
@@ -173,16 +173,26 @@ Internet-Draft                    codcp                        June 2022
    For authentication we can have a mix of PKI and DANE.  Options are
    one of the two and not the other, both or one of the two.
 
-   A poorly constructed DNS client proxy may forward DNS packets without
-   properly handling of EDNS(0) options.  To detect and prevent this, we
-   introduce an option that limits the connection to host-local, link-
-   local, or site-local.  The requirement on a conforming DNS client
-   proxy is to check where a request comes from and compare this to the
-   option in the request (if any).  An error is returned if there is a
-   mismatch.
-
    In a response, the proxy reports the interface, resolver, and
    transport used.
+
+   As described in Section 3 of [RFC5625], some simple DNS proxies may
+   just forward DNS packets without handling of EDNS(0) options.  So
+   what could happen is that an application sends a privacy sensitive
+   request to local proxy, expecting the proxy upstream connection to be
+   encrypted.  However, a simple proxy may just forward the request
+   unencrypted to another proxy, for exmaple, one in a CPE that does
+   implement the protocol described in this document.  So what could
+   happen is that the request travels unencrypted over a local lan, or
+   if proxies deeper in the network support this protocol, even further
+   without the application noticing that something is wrong.
+
+   To handle this case, we introduce an option that limits the
+   connection between the stub resolver and the proxy to host-local,
+   link-local, or site-local.  The requirement on a conforming DNS
+   client proxy is to check where a request comes from and compare this
+   to the option in the request (if any).  An error is returned if there
+   is a mismatch.
 
    In the ideal case, the host operating system provides applications
    with a secure way to access a DNSSEC trust anchor that is maintained
@@ -208,6 +218,14 @@ Internet-Draft                    codcp                        June 2022
    specifies which transports a proxy should use to connect to a
    recursive resolver.
 
+
+
+
+Homburg                  Expires 5 December 2022                [Page 4]
+
+Internet-Draft                    codcp                        June 2022
+
+
    The second option, called PROXY SCOPE Option, controls the IP address
    scope of the connection between the application's stub resolver and
    the proxy.
@@ -216,15 +234,6 @@ Internet-Draft                    codcp                        June 2022
    DNSSEC trust anchor signed by IANA.
 
 5.  PROXY CONTROL OPTION
-
-
-
-
-
-Homburg                  Expires 5 December 2022                [Page 4]
-
-Internet-Draft                    codcp                        June 2022
-
 
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
     0: |                          OPTION-CODE                          |
@@ -265,6 +274,14 @@ Internet-Draft                    codcp                        June 2022
       force the use of unencrypted communication (Do53)
 
    UA
+
+
+
+Homburg                  Expires 5 December 2022                [Page 5]
+
+Internet-Draft                    codcp                        June 2022
+
+
       require unauthenticated encryption
 
    A 
@@ -274,14 +291,6 @@ Internet-Draft                    codcp                        June 2022
       authenticate using a PKI certificate
 
    D 
-
-
-
-Homburg                  Expires 5 December 2022                [Page 5]
-
-Internet-Draft                    codcp                        June 2022
-
-
       authenticate using DANE
 
    DO
@@ -322,6 +331,13 @@ Internet-Draft                    codcp                        June 2022
    Interface Name Length
       length of Interface Name
 
+
+
+Homburg                  Expires 5 December 2022                [Page 6]
+
+Internet-Draft                    codcp                        June 2022
+
+
    Interface Name
       name of outgoing interface for transport connections
 
@@ -330,14 +346,6 @@ Internet-Draft                    codcp                        June 2022
    generate requirements for properties of DNS transports that are used
    by the client proxy.  The U flag specifies no encryption, the UA
    flag, at least unauthenticated encryption and the A flag require
-
-
-
-Homburg                  Expires 5 December 2022                [Page 6]
-
-Internet-Draft                    codcp                        June 2022
-
-
    authenticated encryptions.  With the U, UA, and A flags clear, an
    effort is made to reach authenticated encryption, if that fails
    unauthenticated encryption and if that fails, fall back to an
@@ -379,6 +387,13 @@ Internet-Draft                    codcp                        June 2022
    the proxy.  [Note: it is unclear at the moment what to do with any
    Service Parameters]
 
+
+
+Homburg                  Expires 5 December 2022                [Page 7]
+
+Internet-Draft                    codcp                        June 2022
+
+
    If the application specifies only an authentication-domain-name then
    the proxy is expected to resolve the name to addresses.  If only
    addresses are specified then the proxy assumes that no name is known
@@ -386,13 +401,6 @@ Internet-Draft                    codcp                        June 2022
    subjectAltName).  If both a name and address are specified then the
    proxy will use the specified addresses and use the name for
    authentication.
-
-
-
-Homburg                  Expires 5 December 2022                [Page 7]
-
-Internet-Draft                    codcp                        June 2022
-
 
    To simplify the encoding of the option, an option with addresses will
    have either IPv4 or IPv6 addresses.  If the application wants to
@@ -423,6 +431,25 @@ Internet-Draft                    codcp                        June 2022
       Scope of the source address of a request.  Scope can have the
       following values:
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Homburg                  Expires 5 December 2022                [Page 8]
+
+Internet-Draft                    codcp                        June 2022
+
+
                             +=======+============+
                             | Value | Scope      |
                             +=======+============+
@@ -442,14 +469,6 @@ Internet-Draft                    codcp                        June 2022
    The purpose of this option is to deal with badly implemented proxies
    that forward DNS traffic without first removing any EDNS(0) options.
    The option requests the DNS proxy that processes the option to report
-
-
-
-Homburg                  Expires 5 December 2022                [Page 8]
-
-Internet-Draft                    codcp                        June 2022
-
-
    the scope of the source address.  The application can specify that
    the connection between the stub resolver and the proxy should have,
    for example, at most host local scope.
@@ -479,6 +498,14 @@ Internet-Draft                    codcp                        June 2022
       Lenght of this option excluding the OPTION-CODE and OPTION-LENGTH
       fields
 
+
+
+
+Homburg                  Expires 5 December 2022                [Page 9]
+
+Internet-Draft                    codcp                        June 2022
+
+
    ANCHORS-XML-LENGTH
       Length of ANCHORS-XML in network byte order
 
@@ -494,17 +521,6 @@ Internet-Draft                    codcp                        June 2022
    This option provides DNSSEC trust anchors as described in [RFC7958].
 
 8.  Protocol Specification
-
-
-
-
-
-
-
-Homburg                  Expires 5 December 2022                [Page 9]
-
-Internet-Draft                    codcp                        June 2022
-
 
 9.  Client Processing
 
@@ -539,6 +555,13 @@ Internet-Draft                    codcp                        June 2022
    SCOPE options as described in this document and optionally sets the
    response code to BADPROXYPOLICY specified policy.
 
+
+
+Homburg                  Expires 5 December 2022               [Page 10]
+
+Internet-Draft                    codcp                        June 2022
+
+
 9.2.  Trust Anchor
 
    In the ideal case, the host operating system provides applications
@@ -549,18 +572,6 @@ Internet-Draft                    codcp                        June 2022
    requests to data.iana.org to obtain the trust anchor XML file and the
    signature over the trust anchor.  For this reason, it makes sense to
    let the proxy cache this information.
-
-
-
-
-
-
-
-
-Homburg                  Expires 5 December 2022               [Page 10]
-
-Internet-Draft                    codcp                        June 2022
-
 
    If the local operating system does not provide a DNSSEC trust anchor,
    then the application can ask the proxy.  The stub resolver adds the
@@ -596,6 +607,17 @@ Internet-Draft                    codcp                        June 2022
    recursive resolvers then the proxy generates options with the
    properties of those connection, with a maximum of three connections.
 
+
+
+
+
+
+
+Homburg                  Expires 5 December 2022               [Page 11]
+
+Internet-Draft                    codcp                        June 2022
+
+
    If the proxy finds a PROXY SCOPE Option, then it calculates the scope
    from the source address.  If the scope is larger then specified in
    the option, then the proxy returns a BADPROXYPOLICY response code.
@@ -609,14 +631,6 @@ Internet-Draft                    codcp                        June 2022
    cache this information.  [RFC7958] Does not describe how long these
    documents can be cache.  A simple solution is to take the Expires
    header in the HTTP reply.
-
-
-
-
-Homburg                  Expires 5 December 2022               [Page 11]
-
-Internet-Draft                    codcp                        June 2022
-
 
 11.  Connection Between Stub Resolver And Proxy
 
@@ -652,6 +666,14 @@ Internet-Draft                    codcp                        June 2022
    IANA has assigned the following DNS response code as an early
    allocation per [RFC7120]:
 
+
+
+
+Homburg                  Expires 5 December 2022               [Page 12]
+
+Internet-Draft                    codcp                        June 2022
+
+
     RCODE    Name             Description                   Reference
    -------- ---------------- ----------------------------- -----------
     TBD      BADPROXYPOLICY   Unable to conform to policy   RFC xxxx
@@ -662,17 +684,6 @@ Internet-Draft                    codcp                        June 2022
    feedback.
 
 15.  Normative References
-
-
-
-
-
-
-
-Homburg                  Expires 5 December 2022               [Page 12]
-
-Internet-Draft                    codcp                        June 2022
-
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -698,6 +709,10 @@ Internet-Draft                    codcp                        June 2022
               Trust Anchors", STD 74, RFC 5011, DOI 10.17487/RFC5011,
               September 2007, <https://www.rfc-editor.org/info/rfc5011>.
 
+   [RFC5625]  Bellis, R., "DNS Proxy Implementation Guidelines",
+              BCP 152, RFC 5625, DOI 10.17487/RFC5625, August 2009,
+              <https://www.rfc-editor.org/info/rfc5625>.
+
    [RFC6891]  Damas, J., Graff, M., and P. Vixie, "Extension Mechanisms
               for DNS (EDNS(0))", STD 75, RFC 6891,
               DOI 10.17487/RFC6891, April 2013,
@@ -706,6 +721,14 @@ Internet-Draft                    codcp                        June 2022
    [RFC7120]  Cotton, M., "Early IANA Allocation of Standards Track Code
               Points", BCP 100, RFC 7120, DOI 10.17487/RFC7120, January
               2014, <https://www.rfc-editor.org/info/rfc7120>.
+
+
+
+
+Homburg                  Expires 5 December 2022               [Page 13]
+
+Internet-Draft                    codcp                        June 2022
+
 
    [RFC7540]  Belshe, M., Peon, R., and M. Thomson, Ed., "Hypertext
               Transfer Protocol Version 2 (HTTP/2)", RFC 7540,
@@ -722,14 +745,6 @@ Internet-Draft                    codcp                        June 2022
               RFC 7958, DOI 10.17487/RFC7958, August 2016,
               <https://www.rfc-editor.org/info/rfc7958>.
 
-
-
-
-Homburg                  Expires 5 December 2022               [Page 13]
-
-Internet-Draft                    codcp                        June 2022
-
-
    [RFC8484]  Hoffman, P. and P. McManus, "DNS Queries over HTTPS
               (DoH)", RFC 8484, DOI 10.17487/RFC8484, October 2018,
               <https://www.rfc-editor.org/info/rfc8484>.
@@ -744,21 +759,6 @@ Author's Address
    Philip Homburg
 
    Email: philip@nlnetlabs.nl
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/notes/dns-client-proxy.txt
+++ b/notes/dns-client-proxy.txt
@@ -75,16 +75,16 @@ Table of Contents
    7.  TRUST ANCHOR OPTION . . . . . . . . . . . . . . . . . . . . .   9
    8.  Protocol Specification  . . . . . . . . . . . . . . . . . . .  10
    9.  Client Processing . . . . . . . . . . . . . . . . . . . . . .  10
-     9.1.  Probing . . . . . . . . . . . . . . . . . . . . . . . . .  10
+     9.1.  Probing . . . . . . . . . . . . . . . . . . . . . . . . .  11
      9.2.  Trust Anchor  . . . . . . . . . . . . . . . . . . . . . .  11
-   10. Server Processing . . . . . . . . . . . . . . . . . . . . . .  11
+   10. Server Processing . . . . . . . . . . . . . . . . . . . . . .  12
    11. Connection Between Stub Resolver And Proxy  . . . . . . . . .  12
-   12. Security Considerations . . . . . . . . . . . . . . . . . . .  12
-   13. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  12
+   12. Security Considerations . . . . . . . . . . . . . . . . . . .  13
+   13. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
    14. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  13
    15. Normative References  . . . . . . . . . . . . . . . . . . . .  13
    16. Informative References  . . . . . . . . . . . . . . . . . . .  13
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  14
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  15
 
 1.  Definitions
 
@@ -413,6 +413,19 @@ Internet-Draft                    codcp                        June 2022
    specify both IPv4 and IPv6 addresses for a certain authentication-
    domain-name then it has to include two options.
 
+   An application may want to specify a DNS resolver that is reachable
+   through an IPv6 link-local address.  IPv6 link-local addresses are
+   special in that they require a zone to be specified, either
+   explicitly or implicitly.  Typically for a link-local address that
+   appears as a source or destination address, the zone is implicitly
+   the zone of the link the packet travels on.  For packets that travel
+   between hosts, there is no goed way to explictly specify the zone of
+   a link-local address because two different hosts do not agree on zone
+   names.  However, if the proxy is on the same host as the application,
+   then the zone identifier for the link-local address can be specified
+   in the Interface field.  For this purpose an interface name can also
+   be an interface index expressed as a decimal string.
+
    When present, Service Parameters specify how to connect.  Otherwise
    it is up to the proxy to try various possibilities.
 
@@ -422,6 +435,20 @@ Internet-Draft                    codcp                        June 2022
    it can do.
 
 6.  PROXY SCOPE OPTION
+
+
+
+
+
+
+
+
+
+
+Homburg                  Expires 9 December 2022                [Page 8]
+
+Internet-Draft                    codcp                        June 2022
+
 
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
     0: |                          OPTION-CODE                          |
@@ -441,14 +468,6 @@ Internet-Draft                    codcp                        June 2022
    Scope
       Scope of the source address of a request.  Scope can have the
       following values:
-
-
-
-
-Homburg                  Expires 9 December 2022                [Page 8]
-
-Internet-Draft                    codcp                        June 2022
-
 
                             +=======+============+
                             | Value | Scope      |
@@ -475,6 +494,18 @@ Internet-Draft                    codcp                        June 2022
 
 7.  TRUST ANCHOR OPTION
 
+
+
+
+
+
+
+
+Homburg                  Expires 9 December 2022                [Page 9]
+
+Internet-Draft                    codcp                        June 2022
+
+
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
     0: |                          OPTION-CODE                          |
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
@@ -497,14 +528,6 @@ Internet-Draft                    codcp                        June 2022
    OPTION-LENGTH
       Lenght of this option excluding the OPTION-CODE and OPTION-LENGTH
       fields
-
-
-
-
-Homburg                  Expires 9 December 2022                [Page 9]
-
-Internet-Draft                    codcp                        June 2022
-
 
    ANCHORS-XML-LENGTH
       Length of ANCHORS-XML in network byte order
@@ -531,6 +554,14 @@ Internet-Draft                    codcp                        June 2022
    requests, the Scope field is set to largest scope that the
    application can accept.
 
+
+
+
+Homburg                  Expires 9 December 2022               [Page 10]
+
+Internet-Draft                    codcp                        June 2022
+
+
    If the stub resolver receives a reply without a PROXY CONTROL Option
    included in the reply, then stub resolver has to assume that traffic
    will have Do53 levels of privacy.  Similarly, a lack of a PROXY SCOPE
@@ -555,13 +586,6 @@ Internet-Draft                    codcp                        June 2022
    SCOPE options as described in this document and optionally sets the
    response code to BADPROXYPOLICY specified policy.
 
-
-
-Homburg                  Expires 9 December 2022               [Page 10]
-
-Internet-Draft                    codcp                        June 2022
-
-
 9.2.  Trust Anchor
 
    In the ideal case, the host operating system provides applications
@@ -579,6 +603,20 @@ Internet-Draft                    codcp                        June 2022
    If the proxy returns both an ANCHORS-XML and an ANCHORS-P7S, then the
    application verifies the trust anchor using the trust anchor
    certificate (which needs to come with the application).
+
+
+
+
+
+
+
+
+
+
+Homburg                  Expires 9 December 2022               [Page 11]
+
+Internet-Draft                    codcp                        June 2022
+
 
 10.  Server Processing
 
@@ -607,17 +645,6 @@ Internet-Draft                    codcp                        June 2022
    recursive resolvers then the proxy generates options with the
    properties of those connection, with a maximum of three connections.
 
-
-
-
-
-
-
-Homburg                  Expires 9 December 2022               [Page 11]
-
-Internet-Draft                    codcp                        June 2022
-
-
    If the proxy finds a PROXY SCOPE Option, then it calculates the scope
    from the source address.  If the scope is larger then specified in
    the option, then the proxy returns a BADPROXYPOLICY response code.
@@ -638,6 +665,14 @@ Internet-Draft                    codcp                        June 2022
    standard SHOULD connect to the proxy using Do53 and as remote address
    either ::1 or 127.0.0.1.  In particular, the stub resolver SHOULD
    avoid using name servers listed in files such as /etc/resolv.conf.
+
+
+
+
+Homburg                  Expires 9 December 2022               [Page 12]
+
+Internet-Draft                    codcp                        June 2022
+
 
    The reason for this is to simplify the integration of local DNS
    proxies in existing environments.  If the stub resolver ignores /etc/
@@ -666,14 +701,6 @@ Internet-Draft                    codcp                        June 2022
    IANA has assigned the following DNS response code as an early
    allocation per [RFC7120]:
 
-
-
-
-Homburg                  Expires 9 December 2022               [Page 12]
-
-Internet-Draft                    codcp                        June 2022
-
-
     RCODE    Name             Description                   Reference
    -------- ---------------- ----------------------------- -----------
     TBD      BADPROXYPOLICY   Unable to conform to policy   RFC xxxx
@@ -695,6 +722,13 @@ Internet-Draft                    codcp                        June 2022
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
 16.  Informative References
+
+
+
+Homburg                  Expires 9 December 2022               [Page 13]
+
+Internet-Draft                    codcp                        June 2022
+
 
    [RFC1035]  Mockapetris, P., "Domain names - implementation and
               specification", STD 13, RFC 1035, DOI 10.17487/RFC1035,
@@ -722,14 +756,6 @@ Internet-Draft                    codcp                        June 2022
               Points", BCP 100, RFC 7120, DOI 10.17487/RFC7120, January
               2014, <https://www.rfc-editor.org/info/rfc7120>.
 
-
-
-
-Homburg                  Expires 9 December 2022               [Page 13]
-
-Internet-Draft                    codcp                        June 2022
-
-
    [RFC7540]  Belshe, M., Peon, R., and M. Thomson, Ed., "Hypertext
               Transfer Protocol Version 2 (HTTP/2)", RFC 7540,
               DOI 10.17487/RFC7540, May 2015,
@@ -748,6 +774,17 @@ Internet-Draft                    codcp                        June 2022
    [RFC8484]  Hoffman, P. and P. McManus, "DNS Queries over HTTPS
               (DoH)", RFC 8484, DOI 10.17487/RFC8484, October 2018,
               <https://www.rfc-editor.org/info/rfc8484>.
+
+
+
+
+
+
+
+Homburg                  Expires 9 December 2022               [Page 14]
+
+Internet-Draft                    codcp                        June 2022
+
 
    [RFC9000]  Iyengar, J., Ed. and M. Thomson, Ed., "QUIC: A UDP-Based
               Multiplexed and Secure Transport", RFC 9000,
@@ -781,4 +818,23 @@ Author's Address
 
 
 
-Homburg                  Expires 9 December 2022               [Page 14]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Homburg                  Expires 9 December 2022               [Page 15]

--- a/notes/dns-client-proxy.txt
+++ b/notes/dns-client-proxy.txt
@@ -42,6 +42,14 @@ is the outgoing interface that is to be used.
 For authentication we can have a mix of PKI and DANE. Options are one of 
 the two and not the other, both or one of the two.
 
+Verification of the transport between stub resolver and DNS client proxy.
+A poorly constructed DNS client proxy may forward DNS packet without
+properly handling of EDNS options. To detect and prevent this,
+we introduce an option that limits the connection to host-local, link-local,
+or site-local. The requirement on a conforming DNS client proxy is to
+check where a request comes from and compare this to the option in
+the request (if any). And error is returned if there is a mismatch.
+
 In a reponse, the proxy reports the interface, resolver, and transport
 used.
 
@@ -70,9 +78,11 @@ For future transports (which are unknown the application) we can have:
 by avoiding all known transports)
 
 Then we can extend this even further by adding an IP address and/or a name.
-(open question, if we have only an IP address, can we figure out the name?)
+(open question, if we have only an IP address, can we figure out the name?
+draft-ietf-add-ddr mentions certificates with IP addresses in the
+subjectAltName. Do those exist?)
 If we have only a name, then DNS resolution with implicit resolvers will be
 used to resolve the name. If we have a name and an address, connect to
 the address and use the name for authentication.
 
-
+Note for encoding: similar to draft-ietf-add-dnr

--- a/notes/dns-client-proxy.txt
+++ b/notes/dns-client-proxy.txt
@@ -1,88 +1,728 @@
+
+
+
+
+ADD                                                         P.C. Homburg
+Internet-Draft                                                2 May 2022
+Intended status: Standards Track                                        
+Expires: 3 November 2022
+
+
+                 Control Options For DNS Client Proxies
+                         draft-homburg-codcp-00
+
 Abstract
 
-The introduction of many new transport portocols for DNS in recent years
-(DoT, DoH, DoQ) significantly increases the complexity of DNS stub
-resolvers that want to support these protocols. A practical way forward
-is to have a DNS client proxy in the host operating system. This allows
-applications to communicate using Do53 and still get the privacy
-benefit from using more secure protocols over the internet. However,
-such a setup leaves the application with no control over which transport
-the proxy uses. This document introduces EDNS options that allow a
-stub resolver to request certain transport and allow the proxy to report
-capabilities and actual transports that are available.
+   The introduction of many new transport portocols for DNS in recent
+   years (DoT, DoH, DoQ) significantly increases the complexity of DNS
+   stub resolvers that want to support these protocols.  A practical way
+   forward is to have a DNS client proxy in the host operating system.
+   This allows applications to communicate using Do53 and still get the
+   privacy benefit from using more secure protocols over the internet.
+   However, such a setup leaves the application with no control over
+   which transport the proxy uses.  This document introduces EDNS(0)
+   options that allow a stub resolver to request certain transport and
+   allow the proxy to report capabilities and actual transports that are
+   available.
+
+Status of This Memo
+
+   This Internet-Draft is submitted in full conformance with the
+   provisions of BCP 78 and BCP 79.
+
+   Internet-Drafts are working documents of the Internet Engineering
+   Task Force (IETF).  Note that other groups may also distribute
+   working documents as Internet-Drafts.  The list of current Internet-
+   Drafts is at https://datatracker.ietf.org/drafts/current/.
+
+   Internet-Drafts are draft documents valid for a maximum of six months
+   and may be updated, replaced, or obsoleted by other documents at any
+   time.  It is inappropriate to use Internet-Drafts as reference
+   material or to cite them other than as "work in progress."
+
+   This Internet-Draft will expire on 3 November 2022.
+
+Copyright Notice
+
+   Copyright (c) 2022 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents (https://trustee.ietf.org/
+   license-info) in effect on the date of publication of this document.
 
 
-Introduction
 
-<repeat and extend abstract>
+Homburg                  Expires 3 November 2022                [Page 1]
+
+Internet-Draft                    codcp                         May 2022
 
-For short-lived applications, the overhead of setting a DoH connection
-is quite high if the application only needs to send a few DNS requests.
 
-A local proxy may provide some benefit to short-lived applications by
-caching results. In particular if the system uses a so called 'public
-DNS resolver'. In general we assume that the cache is tagged according
-to the source of a reply and the transport it is received on. 
+   Please review these documents carefully, as they describe your rights
+   and restrictions with respect to this document.  Code Components
+   extracted from this document must include Simplified BSD License text
+   as described in Section 4.e of the Trust Legal Provisions and are
+   provided without warranty as described in the Simplified BSD License.
 
-With respect to DNSSEC, we assume that an application that needs
-DNSSEC validation, for example, for DANE validation or SSHFP, will 
-perform the DNSSEC validation within the application itself and does not
-trust the proxy. The proxy can ofcourse do DNSSEC validation as well.
-Important however, is that an untrusted proxy cannot provide an application
-with a traditional (unsigned) trust anchor.
+Table of Contents
 
-For the transport configuration we expect three levels of details. The
-first is a choice between anythings goes, optimistic encryption and
-authenticated encryption. The second level is where the application also
-specifies the names and/or IP addresses of upstream resolvers. The
-third level is where the application also specifies which transports
-(Do53, DoT, DoH, DoQ) are allowed to be used. A final transport parameter
-is the outgoing interface that is to be used.
+   1.  Definitions . . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+   3.  Key Words . . . . . . . . . . . . . . . . . . . . . . . . . .   4
+   4.  Description . . . . . . . . . . . . . . . . . . . . . . . . .   4
+   5.  PROXY CONTROL OPTION  . . . . . . . . . . . . . . . . . . . .   4
+   6.  PROXY SCOPE OPTION  . . . . . . . . . . . . . . . . . . . . .   7
+   7.  TRUST ANCHOR OPTION . . . . . . . . . . . . . . . . . . . . .   8
+   8.  Protocol Specification  . . . . . . . . . . . . . . . . . . .   9
+   9.  Client Processing . . . . . . . . . . . . . . . . . . . . . .   9
+     9.1.  Probing . . . . . . . . . . . . . . . . . . . . . . . . .  10
+     9.2.  Trust Anchor  . . . . . . . . . . . . . . . . . . . . . .  10
+   10. Server Processing . . . . . . . . . . . . . . . . . . . . . .  11
+   11. Connection Between Stub Resolver And Proxy  . . . . . . . . .  11
+   12. Security Considerations . . . . . . . . . . . . . . . . . . .  12
+   13. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  12
+   14. Normative References  . . . . . . . . . . . . . . . . . . . .  12
+   15. Informative References  . . . . . . . . . . . . . . . . . . .  12
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  13
 
-For authentication we can have a mix of PKI and DANE. Options are one of 
-the two and not the other, both or one of the two.
+1.  Definitions
 
-Verification of the transport between stub resolver and DNS client proxy.
-A poorly constructed DNS client proxy may forward DNS packet without
-properly handling of EDNS options. To detect and prevent this,
-we introduce an option that limits the connection to host-local, link-local,
-or site-local. The requirement on a conforming DNS client proxy is to
-check where a request comes from and compare this to the option in
-the request (if any). And error is returned if there is a mismatch.
+   Do53  The original, plain text DNS transport as described in
+      [RFC1035].  Typically, UDP is used, with the DNS server listening
+      on port 53.  Sometimes, for example, for large responses, TCP is
+      used, also on port 53.
 
-In a reponse, the proxy reports the interface, resolver, and transport
-used.
+   DoH  DNS over HTTPS as described in [RFC8484].
 
-The proxy can provide an application with a signed trust anchor.
+   DoT  DNS over TLS as described in [RFC7858]
 
-Description
+   DoQ  DNS over QUIC ([RFC9000]) as described in [I-D.ietf-dprive-
+      dnsoquic], not to be confused with DNS over HTTP/3 which also uses
+      QUIC
 
-The most basic option has 5 flags:
-- force unencrypted (Do53)
-- at least optimistic encryption (DoT, DoH does not allow optimistic
-  encryption, what about DoQ)
-- authenticated encryption 
-- authenticate using PKI only
-- authenticate using DANE only
+   EDNS(0) Option  An option as described in [RFC6891]
 
-An extended option has these flags and has per transport (Do53, DoT, DoH,
-DoQ) flags for
-- allow this transport
-- avoid this transport 
-- require this transport
+   h2  This TLS ALPN identifies HTTP/2 as described in [RFC7540]
 
-For future transports (which are unknown the application) we can have:
-- allow future transports
-- avoid future transports
-(require future transports, which is a weird thing to do, could be achieved
-by avoiding all known transports)
+   h3  This TLS ALPN identifies HTTP/3, which is HTTP over QUIC and is
+      described in I.D.ietf-quic-http (expired draft)
 
-Then we can extend this even further by adding an IP address and/or a name.
-(open question, if we have only an IP address, can we figure out the name?
-draft-ietf-add-ddr mentions certificates with IP addresses in the
-subjectAltName. Do those exist?)
-If we have only a name, then DNS resolution with implicit resolvers will be
-used to resolve the name. If we have a name and an address, connect to
-the address and use the name for authentication.
 
-Note for encoding: similar to draft-ietf-add-dnr
+
+Homburg                  Expires 3 November 2022                [Page 2]
+
+Internet-Draft                    codcp                         May 2022
+
+
+   Interface Name  A name that identifies a network interface as
+      described in [RFC3493].  In addition, an interface index converted
+      to a decimal number is also consider an interface name.
+
+2.  Introduction
+
+   The introduction of many new transport portocols for DNS in recent
+   years (DoT, DoH, DoQ) significantly increases the complexity of DNS
+   stub resolvers that want to support these protocols.  In addition,
+   for short-lived applications, the overhead of setting a DoH
+   connection is quite high if the application only needs to send a few
+   DNS requests.
+
+   A practical way forward is to have a DNS client proxy in the host
+   operating system.  A local proxy may provide some benefit to short-
+   lived applications by caching results.  In particular if the system
+   uses a so called 'public DNS resolver'.  In general we assume that
+   the cache is tagged according to the source of a reply and the
+   transport it is received on.
+
+   This allows applications to communicate using Do53 and still get the
+   privacy benefits from using more secure protocols over the internet.
+   However, such a setup leaves the application with no control over
+   which transport the proxy uses.  This document introduces EDNS(0)
+   options that allow a stub resolver to request certain transports and
+   allow the proxy to report capabilities and actual transports that are
+   available.
+
+   With respect to DNSSEC, we assume that an application that needs
+   DNSSEC validation, for example, for DANE validation or SSHFP, will
+   perform the DNSSEC validation within the application itself and does
+   not trust the proxy.  The proxy can ofcourse do DNSSEC validation as
+   well.  Important however, is that an untrusted proxy cannot provide
+   an application with a traditional (unsigned) trust anchor.
+
+   For the transport configuration we expect three levels of details.
+   The first is a choice between anythings goes, optimistic encryption
+   and authenticated encryption.  The second level is where the
+   application also specifies the names and/or IP addresses of upstream
+   resolvers.  The third level is where the application also specifies
+   which transports (Do53, DoT, DoH, DoQ) are allowed to be used.  A
+   final transport parameter is the outgoing interface that is to be
+   used.
+
+   For authentication we can have a mix of PKI and DANE.  Options are
+   one of the two and not the other, both or one of the two.
+
+
+
+
+
+Homburg                  Expires 3 November 2022                [Page 3]
+
+Internet-Draft                    codcp                         May 2022
+
+
+   A poorly constructed DNS client proxy may forward DNS packets without
+   properly handling of EDNS(0) options.  To detect and prevent this, we
+   introduce an option that limits the connection to host-local, link-
+   local, or site-local.  The requirement on a conforming DNS client
+   proxy is to check where a request comes from and compare this to the
+   option in the request (if any).  And error is returned if there is a
+   mismatch.
+
+   In a reponse, the proxy reports the interface, resolver, and
+   transport used.
+
+   In the ideal case, the host operating system provides applications
+   with a secure way to access a DNSSEC trust anchor that is maintained
+   according to [RFC5011].  However in situations where this is not the
+   case, an application can fall back to [RFC7958].  However, for short
+   lived processes, there is considerable overhead in issuing to HTTP(S)
+   requests to data.iana.org to obtain the trust anchor XML file and the
+   signature over the trust anchor.  For this reason, it makes sense to
+   let the proxy cache this information.
+
+3.  Key Words
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in BCP
+   14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+4.  Description
+
+   This document introduces the new EDNS(0) options, and one new status
+   code.  This first option, called PROXY CONTROL Option, specifies
+   which transports a proxy should use to connect to a recursive
+   resolver.
+
+   The second option, called PROXY SCOPE Option, controls the IP address
+   scope of the connection between the application's stub resolver and
+   the proxy.
+
+   Finally, the TRUST ANCHOR Option, provides the application with a
+   DNSSEC trust anchor signed by IANA.
+
+5.  PROXY CONTROL OPTION
+
+
+
+
+
+
+
+
+Homburg                  Expires 3 November 2022                [Page 4]
+
+Internet-Draft                    codcp                         May 2022
+
+
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    0: |                          OPTION-CODE                          |
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    2: |                         OPTION-LENGTH                         |
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    4: | U | O | A | P | D |DO |                     Z                 |
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    6: |A53|D53|AT |DT |AH2|DH2|AH3|DH3|AQ |DQ |         Z             |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    8: |         Addr Type             |         Addr Length           |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-|
+       ~                IPv4 or IPv6-address(es)                       ~
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+       |  Domain Name Length           |                               |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
+       ~                   Domain Name                                 ~
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |          SvcParams Length     |                               |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
+       ~                 SvcParams                                     ~
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+       |     Interface Name Length     |                               |
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
+       ~                 Interface Name                                ~
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   where
+
+   OPTION-CODE
+      To be decided
+
+   OPTION-LENGTH
+      Lenght of this option excluding the OPTION-CODE and OPTION-LENGTH
+      fields
+
+   U 
+      force the use of unencrypted communication (Do53)
+
+   O 
+      use at least optimistic encryption
+
+   A 
+      require authenticated encryption
+
+   P 
+      authenticate using a PKI certificate
+
+   D 
+
+
+
+Homburg                  Expires 3 November 2022                [Page 5]
+
+Internet-Draft                    codcp                         May 2022
+
+
+      authenticate using DANE
+
+   DO
+      disallow other transports (transports that are not explicitly
+      listed)
+
+   A53,AT,AH2,AH3,AQ
+      allow respectively Do53, DoT, DoH H2, DoH H3, DoQ
+
+   D53,DT,DH2,DH3,DQ
+      disallow respectively Do53, DoT, DoH H2, DoH H3, DoQ
+
+   Z 
+      reserved, MUST be zero when sending, MUST be ignored when received
+
+   Addr Type
+      Type of addresses, IPv4 or IPv6
+
+   Addr Length
+      length of the addresses in octets.  Must be a multiple of 4 for
+      IPv4 and a multiple of 16 for IPv6
+
+   IPv4 or IPv6-address(es)
+      list of IPv4 or IPv6 addresses
+
+   Domain Name Length
+      length of Domain Name.  Zero if there is no Domain Name
+
+   Domain Name
+      domain name for authentication or resolving IP addresses
+
+   SvcParams Length
+      length of SvcParams
+
+   SvcParams
+      Service parameters
+
+   Interface Name Length
+      length of Interface Name
+
+   Interface Name
+      name of outgoing interface for transport connections
+
+
+
+
+
+
+
+
+
+Homburg                  Expires 3 November 2022                [Page 6]
+
+Internet-Draft                    codcp                         May 2022
+
+
+   This option is designed to give control over what level of detail it
+   wants to specify.  The first 5 flags (U, O, A, P, and D) give
+   generate requirements for properties of DNS transports that are used
+   by the client proxy.  The U flag specifies no encryption, the O flag,
+   at least optimistic encryption and the A flag require authenticated
+   encryptions.  The P and D flags allow the application to require a
+   specfic authentication mechanism (PKI or DANE).
+
+   The next flags provide more detailed control over which transports
+   should be used or not.  For each of 5 different transports (Do53,
+   DoT, DoH with ALPN h2, DoH with ALPN h3, DoQ) there is a flag to
+   allow (A53,AT,AH2,AH3,AQ) or disallow (D53,DT,DH2,DH3,DQ) the use of
+   the transport.  There is space to add more transports later.
+
+   To future proof applications, there is a single flag DO, that
+   disallows transports that are not explicitly listed.  Which this flag
+   clear, the application allows future transports.  With the flag set,
+   the application has to explicitly list which transports can be used.
+   For example, by setting only DO and AT, the application forces the
+   use of DoT.
+
+   Finally, an application can specify it's own resolvers or rely on the
+   resolvers that are know to the proxy.  If ADN Length and Addr Length
+   are both zero, then the application requests to resolvers known to
+   the proxy.  [Note: it is unclear at the moment what to do with any
+   Service Parameters]
+
+   If the application specifies only an authentication-domain-name then
+   the proxy is expect to resolve the name to addresses.  If only
+   addresses are specified then the proxy assumes that no name is known
+   (though a PKI certificate may include an address literal in the
+   subjectAltName).  If both a name and address are specified then the
+   proxy will use the specified addresses and use the name for
+   authentication.
+
+   To simplify the encoding of the option, an option with addresses with
+   have either IPv4 or IPv6 addresses.  If the application wants to
+   specify both IPv4 and IPv6 address for a certain authentication-
+   domain-name then it has to include two options.
+
+   When present, Service Parameters specify how to connect.  Otherwise
+   it is up to the proxy to try various possibilities.
+
+6.  PROXY SCOPE OPTION
+
+
+
+
+
+
+
+Homburg                  Expires 3 November 2022                [Page 7]
+
+Internet-Draft                    codcp                         May 2022
+
+
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    0: |                          OPTION-CODE                          |
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    2: |                         OPTION-LENGTH                         |
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    4: |                          Scope                                |
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+
+   OPTION-CODE
+      To be decided
+
+   OPTION-LENGTH
+      Lenght of this option excluding the OPTION-CODE and OPTION-LENGTH
+      fields
+
+   Scope
+      Scope of the source address of a request.  Scope can have the
+      following values:
+
+                            +=======+============+
+                            | Value | Scope      |
+                            +=======+============+
+                            | 0     | Undefined  |
+                            +-------+------------+
+                            | 1     | Host local |
+                            +-------+------------+
+                            | 2     | Link local |
+                            +-------+------------+
+                            | 3     | Site local |
+                            +-------+------------+
+                            | 4     | Global     |
+                            +-------+------------+
+
+                                   Table 1
+
+   The purpose of this option is deal with badly implemented proxy that
+   forward DNS traffic without first removing any EDNS(0) options.  The
+   option request the DNS proxy that processes the option to report the
+   scope of the source address.  The application can specify that the
+   connection between the stub resolver and the proxy should have, for
+   example, at most host local scope.
+
+7.  TRUST ANCHOR OPTION
+
+
+
+
+
+
+
+
+Homburg                  Expires 3 November 2022                [Page 8]
+
+Internet-Draft                    codcp                         May 2022
+
+
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    0: |                          OPTION-CODE                          |
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    2: |                         OPTION-LENGTH                         |
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    4: |             ANCHORS-XML-LENGTH                                |
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    6: ~             ANCHORS-XML                                       ~
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    4: |             ANCHORS-P7S-LENGTH                                |
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    6: ~             ANCHORS-P7S                                       ~
+       +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   where
+
+   OPTION-CODE
+      To be decided
+
+   OPTION-LENGTH
+      Lenght of this option excluding the OPTION-CODE and OPTION-LENGTH
+      fields
+
+   ANCHORS-XML-LENGTH
+      Length of ANCHORS-XML in network byte order
+
+   ANCHORS-XML
+      Trust anchors in XML format
+
+   ANCHORS-P7S-LENGTH
+      Length of ANCHORS-P7S in network byte order
+
+   ANCHORS-P7S
+      Signature in p7s format
+
+   This option provides DNSSEC trust anchors as described in [RFC7958].
+
+8.  Protocol Specification
+
+9.  Client Processing
+
+   A stub resolver that wishes to use the PROXY CONTROL Option includes
+   the option in all outgoing DNS requests that require privacy.  The
+   option should be initialized according to the needs of the
+   application.  In addition the PROXY SCOPE Option can be added.  In
+   requests, the Scope field is set to largest scope that the
+   application can accept.
+
+
+
+
+Homburg                  Expires 3 November 2022                [Page 9]
+
+Internet-Draft                    codcp                         May 2022
+
+
+   If the stub resolver receives a reply without a PROXY CONTROL Option
+   included in the reply, then stub resolver has to assume that traffic
+   will have Do%3 levels of privacy.  Similarly, a lack of a PROXY SCOPE
+   Option implies a global scope.
+
+   If the stub resolver receives a BADPROXYPOLICY error then the proxy
+   was unable to meet the requirements of the option(s).  In the reply,
+   the proxy modifies the options to show what it can do.
+
+9.1.  Probing
+
+   In cases where the stub resolvers expects a local DNS proxy, or where
+   the stub resolver has (a limited) fall back to more private
+   transports, or when the security policy of the application is such
+   that is better to fail then the send queries over Do53, the stub
+   resolver first sends probing query to verify that the proxy supports
+   the PROXY CONTROL and PROXY SCOPE options.
+
+   This request queries "resolver.arpa".  The proxy MUST implement this
+   as a Special Use Domain Name.  The actual response is not important.
+   The important part is that the proxy returns PROXY CONTROL and PROXY
+   SCOPE options as described in the this documents and optionally sets
+   the result to BADPROXYPOLICY specified policy.
+
+9.2.  Trust Anchor
+
+   In the ideal case, the host operating system provides applications
+   with a secure way to access a DNSSEC trust anchor that is maintained
+   according to [RFC5011].  However in situations where this is not the
+   case, an application can fall back to [RFC7958].  However, for short
+   lived processes, there is considerable overhead in issuing to HTTP(S)
+   requests to data.iana.org to obtain the trust anchor XML file and the
+   signature over the trust anchor.  For this reason, it makes sense to
+   let the proxy cache this information.
+
+   If the local operating system does not provide a DNSSEC trust anchor,
+   then the application can ask the proxy.  The stub resolver adds the
+   TRUST ANCHOR Option with ANCHORS-XML-LENGTH and ANCHORS-P7S-LENGTH.
+   If the proxy returns both an ANCHORS-XML and an ANCHORS-P7S, then the
+   application verifies the trust anchor using the trust anchor
+   certificate (which needs to come with the application).
+
+
+
+
+
+
+
+
+
+
+Homburg                  Expires 3 November 2022               [Page 10]
+
+Internet-Draft                    codcp                         May 2022
+
+
+10.  Server Processing
+
+   Proxies are encouraged to cache options that appear in requests under
+   the assumption that a stub resolver will send multiple requests.  If
+   a proxy caches DNS responses then the proxy MUST tag cached responses
+   with the properties of the DNS transport.  When responding the later
+   requests, then proxy returns a cached entry only if the parameters of
+   the DNS transport match what is specified in the request.
+
+   When a proxy receives a new set of requirements, the proxy compiles a
+   list of addresses to connect to and per address a list of transports
+   to try.  The proxy SHOULD prefer more private transports over less
+   private ones.
+
+   If the proxy cannot obtain a connect to a recursive resolver in a way
+   that matches the provided policy, then the proxy sets the
+   BADPROXYPOLICY status in the reply.  In addition the proxy SHOULD try
+   to find at least one connection to a recursive resolver.  If the
+   proxy did not find an alternative connection to recursive resolver
+   (also if it didn't try) then the proxy include a PROXY POLICY Option
+   with all flags set to zero, and with ADN Length, Addr Length, and
+   SvcParams Length set to zero as well.
+
+   If the proxy does have one or more alternative connections to
+   resursive resolvers then the proxy generates options with the
+   properties of those connection, with a maximum of three connections.
+
+   If the proxy finds a PROXY SCOPE Option, then it calculates the scope
+   from the source address.  If the scope is larger then specified in
+   the option, then the proxy returns a BADPROXYPOLICY status.  The
+   proxy sets the value of Scope to the actual scope of the source
+   address of the request.
+
+   If the request contains a TRUST ANCHOR Option, then the proxy tries
+   to fetch the trust anchor XML and p7s files if it does not have them
+   already.  If fetch one or both fails then the proxy sets the
+   corresponding length to zero.  It is not clear how long the proxy can
+   cache this information.  [RFC7958] Does not describe how long these
+   documents can be cache.  A simple solution is to take the Expires
+   header in the HTTP reply.
+
+11.  Connection Between Stub Resolver And Proxy
+
+   Absent other configuration, a stub resolver that implements this
+   standard SHOULD connect to the proxy using Do53 and as remote address
+   either ::1 or 127.0.0.1.  In particular, the stub resolver SHOULD
+   avoid using name servers listed in files such as /etc/resolv.conf.
+
+
+
+
+Homburg                  Expires 3 November 2022               [Page 11]
+
+Internet-Draft                    codcp                         May 2022
+
+
+   There reason for this is to simply the intergration of local DNS
+   proxies in existing environments.  If the stub resolver ignores /etc/
+   resolv.conf then the proxy can use that information to connect to
+   recursive resolvers.
+
+   If no DNS server is responding to queries sent using Do53 to ::1 and
+   127.0.0.1, or if the response indicates that this standard is not
+   supported, then the stub resolver MAY fall back to traditional
+   configuration methods, such as /etc/resolv.conf.  However, in that
+   case the stub resolver MUST make sure that doing so does not violate
+   the policy set by the application.
+
+12.  Security Considerations
+
+13.  IANA Considerations
+
+   IANA has assigned the following DNS EDNS0 option codes:
+
+    Value   Name           Status     Reference
+   ------- -------------- ---------- -----------
+    TBD     PROXY POLICY   Standard   RFC xxxx
+    TBD     PROXY SCOPE    Standard   RFC xxxx
+    TBD     TRUST ANCHOR   Standard   RFC xxxx
+
+   IANA has assigned the following DNS error code as an early allocation
+   per [RFC7120]:
+
+    RCODE    Name             Description                   Reference
+   -------- ---------------- ----------------------------- -----------
+    TBD      BADPROXYPOLICY   Unable to conform to policy   RFC xxxx
+
+14.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+15.  Informative References
+
+   [RFC1035]  Mockapetris, P., "Domain names - implementation and
+              specification", STD 13, RFC 1035, DOI 10.17487/RFC1035,
+              November 1987, <https://www.rfc-editor.org/info/rfc1035>.
+
+
+
+
+Homburg                  Expires 3 November 2022               [Page 12]
+
+Internet-Draft                    codcp                         May 2022
+
+
+   [RFC3493]  Gilligan, R., Thomson, S., Bound, J., McCann, J., and W.
+              Stevens, "Basic Socket Interface Extensions for IPv6",
+              RFC 3493, DOI 10.17487/RFC3493, February 2003,
+              <https://www.rfc-editor.org/info/rfc3493>.
+
+   [RFC5011]  StJohns, M., "Automated Updates of DNS Security (DNSSEC)
+              Trust Anchors", STD 74, RFC 5011, DOI 10.17487/RFC5011,
+              September 2007, <https://www.rfc-editor.org/info/rfc5011>.
+
+   [RFC6891]  Damas, J., Graff, M., and P. Vixie, "Extension Mechanisms
+              for DNS (EDNS(0))", STD 75, RFC 6891,
+              DOI 10.17487/RFC6891, April 2013,
+              <https://www.rfc-editor.org/info/rfc6891>.
+
+   [RFC7120]  Cotton, M., "Early IANA Allocation of Standards Track Code
+              Points", BCP 100, RFC 7120, DOI 10.17487/RFC7120, January
+              2014, <https://www.rfc-editor.org/info/rfc7120>.
+
+   [RFC7540]  Belshe, M., Peon, R., and M. Thomson, Ed., "Hypertext
+              Transfer Protocol Version 2 (HTTP/2)", RFC 7540,
+              DOI 10.17487/RFC7540, May 2015,
+              <https://www.rfc-editor.org/info/rfc7540>.
+
+   [RFC7858]  Hu, Z., Zhu, L., Heidemann, J., Mankin, A., Wessels, D.,
+              and P. Hoffman, "Specification for DNS over Transport
+              Layer Security (TLS)", RFC 7858, DOI 10.17487/RFC7858, May
+              2016, <https://www.rfc-editor.org/info/rfc7858>.
+
+   [RFC7958]  Abley, J., Schlyter, J., Bailey, G., and P. Hoffman,
+              "DNSSEC Trust Anchor Publication for the Root Zone",
+              RFC 7958, DOI 10.17487/RFC7958, August 2016,
+              <https://www.rfc-editor.org/info/rfc7958>.
+
+   [RFC8484]  Hoffman, P. and P. McManus, "DNS Queries over HTTPS
+              (DoH)", RFC 8484, DOI 10.17487/RFC8484, October 2018,
+              <https://www.rfc-editor.org/info/rfc8484>.
+
+   [RFC9000]  Iyengar, J., Ed. and M. Thomson, Ed., "QUIC: A UDP-Based
+              Multiplexed and Secure Transport", RFC 9000,
+              DOI 10.17487/RFC9000, May 2021,
+              <https://www.rfc-editor.org/info/rfc9000>.
+
+Author's Address
+
+   Philip Homburg
+
+   Email: philip@nlnetlabs.nl
+
+
+
+
+Homburg                  Expires 3 November 2022               [Page 13]

--- a/notes/dns-client-proxy.txt
+++ b/notes/dns-client-proxy.txt
@@ -3,9 +3,9 @@
 
 
 ADD                                                         P.C. Homburg
-Internet-Draft                                               7 July 2022
+Internet-Draft                                              11 July 2022
 Intended status: Standards Track                                        
-Expires: 8 January 2023
+Expires: 12 January 2023
 
 
                  Control Options For DNS Client Proxies
@@ -40,7 +40,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 8 January 2023.
+   This Internet-Draft will expire on 12 January 2023.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Homburg                  Expires 8 January 2023                 [Page 1]
+Homburg                  Expires 12 January 2023                [Page 1]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Homburg                  Expires 8 January 2023                 [Page 2]
+Homburg                  Expires 12 January 2023                [Page 2]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -165,7 +165,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 8 January 2023                 [Page 3]
+Homburg                  Expires 12 January 2023                [Page 3]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -221,7 +221,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 8 January 2023                 [Page 4]
+Homburg                  Expires 12 January 2023                [Page 4]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -277,7 +277,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 8 January 2023                 [Page 5]
+Homburg                  Expires 12 January 2023                [Page 5]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -333,7 +333,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 8 January 2023                 [Page 6]
+Homburg                  Expires 12 January 2023                [Page 6]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -389,7 +389,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 8 January 2023                 [Page 7]
+Homburg                  Expires 12 January 2023                [Page 7]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -445,7 +445,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 8 January 2023                 [Page 8]
+Homburg                  Expires 12 January 2023                [Page 8]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -501,7 +501,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 8 January 2023                 [Page 9]
+Homburg                  Expires 12 January 2023                [Page 9]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -557,7 +557,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 8 January 2023                [Page 10]
+Homburg                  Expires 12 January 2023               [Page 10]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -613,7 +613,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 8 January 2023                [Page 11]
+Homburg                  Expires 12 January 2023               [Page 11]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -669,7 +669,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 8 January 2023                [Page 12]
+Homburg                  Expires 12 January 2023               [Page 12]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -725,7 +725,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 8 January 2023                [Page 13]
+Homburg                  Expires 12 January 2023               [Page 13]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -781,7 +781,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 8 January 2023                [Page 14]
+Homburg                  Expires 12 January 2023               [Page 14]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -837,7 +837,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 8 January 2023                [Page 15]
+Homburg                  Expires 12 January 2023               [Page 15]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -893,4 +893,4 @@ Author's Address
 
 
 
-Homburg                  Expires 8 January 2023                [Page 16]
+Homburg                  Expires 12 January 2023               [Page 16]

--- a/notes/dns-client-proxy.txt
+++ b/notes/dns-client-proxy.txt
@@ -311,7 +311,8 @@ Internet-Draft                    codcp                        June 2022
 
    Addr Length
       length of the addresses in octets.  Must be a multiple of 4 for
-      IPv4 and a multiple of 16 for IPv6
+      IPv4 and a multiple of 16 for IPv6.  This field can be zero if no
+      addresses are specified.
 
    IPv4 or IPv6-address(es)
       list of IPv4 or IPv6 addresses
@@ -323,13 +324,12 @@ Internet-Draft                    codcp                        June 2022
       domain name for authentication or resolving IP addresses
 
    SvcParams Length
-      length of SvcParams
+      length of SvcParams.  Zero if there are no service parameters
+      specified.
 
    SvcParams
       Service parameters
 
-   Interface Name Length
-      length of Interface Name
 
 
 
@@ -337,6 +337,9 @@ Homburg                  Expires 9 December 2022                [Page 6]
 
 Internet-Draft                    codcp                        June 2022
 
+
+   Interface Name Length
+      length of Interface Name.  Zero if no interface is specified.
 
    Interface Name
       name of outgoing interface for transport connections
@@ -381,11 +384,8 @@ Internet-Draft                    codcp                        June 2022
    *  no transports are in the pool of potentially usable transports
    *  A53, AT, AH2, AH3 and AQ add those transports to the pool
 
-   Finally, an application can specify its own resolvers or rely on the
-   resolvers that are know to the proxy.  If ADN Length and Addr Length
-   are both zero, then the application requests to resolvers known to
-   the proxy.  [Note: it is unclear at the moment what to do with any
-   Service Parameters]
+
+
 
 
 
@@ -393,6 +393,12 @@ Homburg                  Expires 9 December 2022                [Page 7]
 
 Internet-Draft                    codcp                        June 2022
 
+
+   Finally, an application can specify its own resolvers or rely on the
+   resolvers that are know to the proxy.  If ADN Length and Addr Length
+   are both zero, then the application requests to resolvers known to
+   the proxy.  [Note: it is unclear at the moment what to do with any
+   Service Parameters]
 
    If the application specifies only an authentication-domain-name then
    the proxy is expected to resolve the name to addresses.  If only
@@ -435,12 +441,6 @@ Internet-Draft                    codcp                        June 2022
    Scope
       Scope of the source address of a request.  Scope can have the
       following values:
-
-
-
-
-
-
 
 
 

--- a/notes/dns-client-proxy.txt
+++ b/notes/dns-client-proxy.txt
@@ -3,9 +3,9 @@
 
 
 ADD                                                         P.C. Homburg
-Internet-Draft                                                2 May 2022
+Internet-Draft                                                6 May 2022
 Intended status: Standards Track                                        
-Expires: 3 November 2022
+Expires: 7 November 2022
 
 
                  Control Options For DNS Client Proxies
@@ -40,7 +40,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 3 November 2022.
+   This Internet-Draft will expire on 7 November 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Homburg                  Expires 3 November 2022                [Page 1]
+Homburg                  Expires 7 November 2022                [Page 1]
 
 Internet-Draft                    codcp                         May 2022
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Homburg                  Expires 3 November 2022                [Page 2]
+Homburg                  Expires 7 November 2022                [Page 2]
 
 Internet-Draft                    codcp                         May 2022
 
@@ -150,13 +150,13 @@ Internet-Draft                    codcp                         May 2022
    an application with a traditional (unsigned) trust anchor.
 
    For the transport configuration we expect three levels of details.
-   The first is a choice between anythings goes, optimistic encryption
-   and authenticated encryption.  The second level is where the
-   application also specifies the names and/or IP addresses of upstream
-   resolvers.  The third level is where the application also specifies
-   which transports (Do53, DoT, DoH, DoQ) are allowed to be used.  A
-   final transport parameter is the outgoing interface that is to be
-   used.
+   The first is a choice between anythings goes, unauthenticated
+   encryption and authenticated encryption.  The second level is where
+   the application also specifies the names and/or IP addresses of
+   upstream resolvers.  The third level is where the application also
+   specifies which transports (Do53, DoT, DoH, DoQ) are allowed to be
+   used.  A final transport parameter is the outgoing interface that is
+   to be used.
 
    For authentication we can have a mix of PKI and DANE.  Options are
    one of the two and not the other, both or one of the two.
@@ -165,7 +165,7 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 3 November 2022                [Page 3]
+Homburg                  Expires 7 November 2022                [Page 3]
 
 Internet-Draft                    codcp                         May 2022
 
@@ -221,7 +221,7 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 3 November 2022                [Page 4]
+Homburg                  Expires 7 November 2022                [Page 4]
 
 Internet-Draft                    codcp                         May 2022
 
@@ -231,7 +231,7 @@ Internet-Draft                    codcp                         May 2022
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
     2: |                         OPTION-LENGTH                         |
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-    4: | U | O | A | P | D |DO |                     Z                 |
+    4: | U |UA | A | P | D |DO |                     Z                 |
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
     6: |A53|D53|AT |DT |AH2|DH2|AH3|DH3|AQ |DQ |         Z             |
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -264,8 +264,8 @@ Internet-Draft                    codcp                         May 2022
    U 
       force the use of unencrypted communication (Do53)
 
-   O 
-      use at least optimistic encryption
+   UA
+      require unauthenticated encryption
 
    A 
       require authenticated encryption
@@ -277,7 +277,7 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 3 November 2022                [Page 5]
+Homburg                  Expires 7 November 2022                [Page 5]
 
 Internet-Draft                    codcp                         May 2022
 
@@ -325,26 +325,27 @@ Internet-Draft                    codcp                         May 2022
    Interface Name
       name of outgoing interface for transport connections
 
+   This option is designed to give control over what level of detail it
+   wants to specify.  The first 5 flags (U, UA, A, P, and D) give
+   generate requirements for properties of DNS transports that are used
+   by the client proxy.  The U flag specifies no encryption, the UA
+   flag, at least unauthenticated encryption and the A flag require
 
 
 
-
-
-
-
-
-Homburg                  Expires 3 November 2022                [Page 6]
+Homburg                  Expires 7 November 2022                [Page 6]
 
 Internet-Draft                    codcp                         May 2022
 
 
-   This option is designed to give control over what level of detail it
-   wants to specify.  The first 5 flags (U, O, A, P, and D) give
-   generate requirements for properties of DNS transports that are used
-   by the client proxy.  The U flag specifies no encryption, the O flag,
-   at least optimistic encryption and the A flag require authenticated
-   encryptions.  The P and D flags allow the application to require a
-   specfic authentication mechanism (PKI or DANE).
+   authenticated encryptions.  With the U, UA, and A flags clear, an
+   effort is made to reach authenticated encryption, if that fails
+   unauthenticated encryption and if that fails, fall back to an
+   unencryption transport.  The P and D flags allow the application to
+   require a specfic authentication mechanism (PKI or DANE).  When both
+   flags are set, PKI and DANE are required together.  If no flags are
+   set, are least one of the two has to succeed if authenticated
+   encryption is required.
 
    The next flags provide more detailed control over which transports
    should be used or not.  For each of 5 different transports (Do53,
@@ -388,8 +389,7 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-
-Homburg                  Expires 3 November 2022                [Page 7]
+Homburg                  Expires 7 November 2022                [Page 7]
 
 Internet-Draft                    codcp                         May 2022
 
@@ -445,7 +445,7 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 3 November 2022                [Page 8]
+Homburg                  Expires 7 November 2022                [Page 8]
 
 Internet-Draft                    codcp                         May 2022
 
@@ -501,7 +501,7 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 3 November 2022                [Page 9]
+Homburg                  Expires 7 November 2022                [Page 9]
 
 Internet-Draft                    codcp                         May 2022
 
@@ -557,7 +557,7 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 3 November 2022               [Page 10]
+Homburg                  Expires 7 November 2022               [Page 10]
 
 Internet-Draft                    codcp                         May 2022
 
@@ -613,7 +613,7 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 3 November 2022               [Page 11]
+Homburg                  Expires 7 November 2022               [Page 11]
 
 Internet-Draft                    codcp                         May 2022
 
@@ -669,7 +669,7 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 3 November 2022               [Page 12]
+Homburg                  Expires 7 November 2022               [Page 12]
 
 Internet-Draft                    codcp                         May 2022
 
@@ -725,4 +725,4 @@ Author's Address
 
 
 
-Homburg                  Expires 3 November 2022               [Page 13]
+Homburg                  Expires 7 November 2022               [Page 13]

--- a/notes/dns-client-proxy.txt
+++ b/notes/dns-client-proxy.txt
@@ -3,9 +3,9 @@
 
 
 ADD                                                         P.C. Homburg
-Internet-Draft                                               3 June 2022
+Internet-Draft                                               7 June 2022
 Intended status: Standards Track                                        
-Expires: 5 December 2022
+Expires: 9 December 2022
 
 
                  Control Options For DNS Client Proxies
@@ -40,7 +40,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 5 December 2022.
+   This Internet-Draft will expire on 9 December 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Homburg                  Expires 5 December 2022                [Page 1]
+Homburg                  Expires 9 December 2022                [Page 1]
 
 Internet-Draft                    codcp                        June 2022
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Homburg                  Expires 5 December 2022                [Page 2]
+Homburg                  Expires 9 December 2022                [Page 2]
 
 Internet-Draft                    codcp                        June 2022
 
@@ -165,7 +165,7 @@ Internet-Draft                    codcp                        June 2022
 
 
 
-Homburg                  Expires 5 December 2022                [Page 3]
+Homburg                  Expires 9 December 2022                [Page 3]
 
 Internet-Draft                    codcp                        June 2022
 
@@ -221,7 +221,7 @@ Internet-Draft                    codcp                        June 2022
 
 
 
-Homburg                  Expires 5 December 2022                [Page 4]
+Homburg                  Expires 9 December 2022                [Page 4]
 
 Internet-Draft                    codcp                        June 2022
 
@@ -277,7 +277,7 @@ Internet-Draft                    codcp                        June 2022
 
 
 
-Homburg                  Expires 5 December 2022                [Page 5]
+Homburg                  Expires 9 December 2022                [Page 5]
 
 Internet-Draft                    codcp                        June 2022
 
@@ -333,7 +333,7 @@ Internet-Draft                    codcp                        June 2022
 
 
 
-Homburg                  Expires 5 December 2022                [Page 6]
+Homburg                  Expires 9 December 2022                [Page 6]
 
 Internet-Draft                    codcp                        June 2022
 
@@ -389,7 +389,7 @@ Internet-Draft                    codcp                        June 2022
 
 
 
-Homburg                  Expires 5 December 2022                [Page 7]
+Homburg                  Expires 9 December 2022                [Page 7]
 
 Internet-Draft                    codcp                        June 2022
 
@@ -409,6 +409,11 @@ Internet-Draft                    codcp                        June 2022
 
    When present, Service Parameters specify how to connect.  Otherwise
    it is up to the proxy to try various possibilities.
+
+   Associated with this option is a new error, BADPROXYPOLICY.  When a
+   proxy cannot meet the requirement in a PROXY CONTROL option, it
+   returns this error along with a PROXY CONTROL option that lists what
+   it can do.
 
 6.  PROXY SCOPE OPTION
 
@@ -440,12 +445,7 @@ Internet-Draft                    codcp                        June 2022
 
 
 
-
-
-
-
-
-Homburg                  Expires 5 December 2022                [Page 8]
+Homburg                  Expires 9 December 2022                [Page 8]
 
 Internet-Draft                    codcp                        June 2022
 
@@ -501,7 +501,7 @@ Internet-Draft                    codcp                        June 2022
 
 
 
-Homburg                  Expires 5 December 2022                [Page 9]
+Homburg                  Expires 9 December 2022                [Page 9]
 
 Internet-Draft                    codcp                        June 2022
 
@@ -557,7 +557,7 @@ Internet-Draft                    codcp                        June 2022
 
 
 
-Homburg                  Expires 5 December 2022               [Page 10]
+Homburg                  Expires 9 December 2022               [Page 10]
 
 Internet-Draft                    codcp                        June 2022
 
@@ -613,7 +613,7 @@ Internet-Draft                    codcp                        June 2022
 
 
 
-Homburg                  Expires 5 December 2022               [Page 11]
+Homburg                  Expires 9 December 2022               [Page 11]
 
 Internet-Draft                    codcp                        June 2022
 
@@ -669,7 +669,7 @@ Internet-Draft                    codcp                        June 2022
 
 
 
-Homburg                  Expires 5 December 2022               [Page 12]
+Homburg                  Expires 9 December 2022               [Page 12]
 
 Internet-Draft                    codcp                        June 2022
 
@@ -725,7 +725,7 @@ Internet-Draft                    codcp                        June 2022
 
 
 
-Homburg                  Expires 5 December 2022               [Page 13]
+Homburg                  Expires 9 December 2022               [Page 13]
 
 Internet-Draft                    codcp                        June 2022
 
@@ -781,4 +781,4 @@ Author's Address
 
 
 
-Homburg                  Expires 5 December 2022               [Page 14]
+Homburg                  Expires 9 December 2022               [Page 14]

--- a/notes/dns-client-proxy.txt
+++ b/notes/dns-client-proxy.txt
@@ -3,13 +3,13 @@
 
 
 ADD                                                         P.C. Homburg
-Internet-Draft                                               5 July 2022
+Internet-Draft                                               7 July 2022
 Intended status: Standards Track                                        
-Expires: 6 January 2023
+Expires: 8 January 2023
 
 
                  Control Options For DNS Client Proxies
-                         draft-homburg-codcp-00
+                       draft-homburg-add-codcp-00
 
 Abstract
 
@@ -40,7 +40,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 6 January 2023.
+   This Internet-Draft will expire on 8 January 2023.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Homburg                  Expires 6 January 2023                 [Page 1]
+Homburg                  Expires 8 January 2023                 [Page 1]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -71,27 +71,27 @@ Table of Contents
    3.  Key Words . . . . . . . . . . . . . . . . . . . . . . . . . .   4
    4.  Description . . . . . . . . . . . . . . . . . . . . . . . . .   4
    5.  PROXY CONTROL OPTION  . . . . . . . . . . . . . . . . . . . .   5
-   6.  PROXY SCOPE OPTION  . . . . . . . . . . . . . . . . . . . . .   9
+   6.  PROXY SCOPE OPTION  . . . . . . . . . . . . . . . . . . . . .  10
    7.  TRUST ANCHOR OPTION . . . . . . . . . . . . . . . . . . . . .  10
    8.  Protocol Specification  . . . . . . . . . . . . . . . . . . .  11
      8.1.  Client Processing . . . . . . . . . . . . . . . . . . . .  11
-       8.1.1.  Probing . . . . . . . . . . . . . . . . . . . . . . .  11
+       8.1.1.  Probing . . . . . . . . . . . . . . . . . . . . . . .  12
        8.1.2.  Trust Anchor  . . . . . . . . . . . . . . . . . . . .  12
-     8.2.  Server Processing . . . . . . . . . . . . . . . . . . . .  12
-   9.  Connection Between Stub Resolver And Proxy  . . . . . . . . .  13
+     8.2.  Server Processing . . . . . . . . . . . . . . . . . . . .  13
+   9.  Connection Between Stub Resolver And Proxy  . . . . . . . . .  14
    10. Security Considerations . . . . . . . . . . . . . . . . . . .  14
    11. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
-   12. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  14
-   13. Normative References  . . . . . . . . . . . . . . . . . . . .  14
+   12. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  15
+   13. Normative References  . . . . . . . . . . . . . . . . . . . .  15
    14. Informative References  . . . . . . . . . . . . . . . . . . .  15
    Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  16
 
 1.  Definitions
 
    Do53  The original, plain text DNS transport as described in
-      [RFC1035].  Typically, UDP is used, with the DNS server listening
-      on port 53.  Sometimes, for example, for large responses, TCP is
-      used, also on port 53.
+      [RFC1034][RFC1035].  Typically, UDP is used, with the DNS server
+      listening on port 53.  Sometimes, for example, for large
+      responses, TCP is used, also on port 53.
 
    DoH  DNS over HTTPS as described in [RFC8484].
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Homburg                  Expires 6 January 2023                 [Page 2]
+Homburg                  Expires 8 January 2023                 [Page 2]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -165,7 +165,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 6 January 2023                 [Page 3]
+Homburg                  Expires 8 January 2023                 [Page 3]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -221,7 +221,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 6 January 2023                 [Page 4]
+Homburg                  Expires 8 January 2023                 [Page 4]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -277,7 +277,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 6 January 2023                 [Page 5]
+Homburg                  Expires 8 January 2023                 [Page 5]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -321,7 +321,7 @@ Internet-Draft                    codcp                        July 2022
 
    Domain Name
       domain name for authentication or resolving IP addresses.  The
-      domain name is encoding in uncompressed DNS wire format.
+      domain name is encoded in uncompressed DNS wire format.
 
    SvcParams Length
       length of SvcParams.  Zero if there are no service parameters
@@ -333,7 +333,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 6 January 2023                 [Page 6]
+Homburg                  Expires 8 January 2023                 [Page 6]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -389,7 +389,7 @@ Internet-Draft                    codcp                        July 2022
 
 
 
-Homburg                  Expires 6 January 2023                 [Page 7]
+Homburg                  Expires 8 January 2023                 [Page 7]
 
 Internet-Draft                    codcp                        July 2022
 
@@ -415,7 +415,7 @@ Internet-Draft                    codcp                        July 2022
    DoT, DoH with ALPN h2, DoH with ALPN h3, DoQ) there is a flag to
    allow (A53,AT,AH2,AH3,AQ) or disallow (D53,DT,DH2,DH3,DQ) the use of
    the transport.  There is space to add more transports later.  Note
-   that setting the A flags and the D flag for a protocol (for example,
+   that setting the A flag and the D flag for a protocol (for example,
    setting both the A53 and the D53 flags) is not allowed and a proxy
    SHOULD reject such a request.
 
@@ -430,25 +430,31 @@ Internet-Draft                    codcp                        July 2022
    When DD = 0:
 
    *  all transports are in the pool of potentially usable transports
-   *  D53, DT, DH2, DH3 and DQ remove those transports from the pool
+   *  D53, DT, DH2, DH3 and DQ remove those transports from the pool.
+   *  The values of A53, AT, AH2, AH3 and AQ are irrelevant
 
    When DD = 1:
 
    *  no transports are in the pool of potentially usable transports
    *  A53, AT, AH2, AH3 and AQ add those transports to the pool
+   *  The values of D53, DT, DH2, DH3 and DQ are irrelevant
+
+
+
+
+
+
+
+Homburg                  Expires 8 January 2023                 [Page 8]
+
+Internet-Draft                    codcp                        July 2022
+
 
    Finally, an application can specify its own resolvers or rely on the
    resolvers that are known to the proxy.  If ADN Length and Addr Length
    are both zero, then the application requests the resolvers known to
    the proxy.  [Note: it is unclear at the moment what to do with any
    Service Parameters]
-
-
-
-Homburg                  Expires 6 January 2023                 [Page 8]
-
-Internet-Draft                    codcp                        July 2022
-
 
    If the application specifies only an authentication-domain-name then
    the proxy is expected to resolve the name to addresses.  If only
@@ -486,6 +492,20 @@ Internet-Draft                    codcp                        July 2022
    proxy cannot meet the requirements in a PROXY CONTROL Option or the
    option is malformed, it returns this error.
 
+   If the proxy returns a BADPROXYPOLICY error, the proxy MAY include a
+   PROXY CONTROL Option that lists what the proxy can do.  For example,
+   if authenticated encryption is not possible, but unauthenticated is,
+   then the proxy may include an option that has the UA bit set.
+
+
+
+
+
+Homburg                  Expires 8 January 2023                 [Page 9]
+
+Internet-Draft                    codcp                        July 2022
+
+
 6.  PROXY SCOPE OPTION
 
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
@@ -498,13 +518,6 @@ Internet-Draft                    codcp                        July 2022
 
    OPTION-CODE
       To be decided
-
-
-
-Homburg                  Expires 6 January 2023                 [Page 9]
-
-Internet-Draft                    codcp                        July 2022
-
 
    OPTION-LENGTH
       Length of this option excluding the OPTION-CODE and OPTION-LENGTH
@@ -537,6 +550,18 @@ Internet-Draft                    codcp                        July 2022
 
 7.  TRUST ANCHOR OPTION
 
+
+
+
+
+
+
+
+Homburg                  Expires 8 January 2023                [Page 10]
+
+Internet-Draft                    codcp                        July 2022
+
+
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
     0: |                          OPTION-CODE                          |
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
@@ -554,14 +579,6 @@ Internet-Draft                    codcp                        July 2022
    where
 
    OPTION-CODE
-
-
-
-Homburg                  Expires 6 January 2023                [Page 10]
-
-Internet-Draft                    codcp                        July 2022
-
-
       To be decided
 
    OPTION-LENGTH
@@ -592,6 +609,15 @@ Internet-Draft                    codcp                        July 2022
    application.  In addition the PROXY SCOPE Option can be added.  In
    requests, the Scope field is set to undefined.
 
+
+
+
+
+Homburg                  Expires 8 January 2023                [Page 11]
+
+Internet-Draft                    codcp                        July 2022
+
+
    If the stub resolver receives a reply without a PROXY CONTROL Option
    included in the reply, then stub resolver has to assume that traffic
    will have Do53 levels of privacy.  Similarly, a lack of a PROXY SCOPE
@@ -608,15 +634,6 @@ Internet-Draft                    codcp                        July 2022
    that is better to fail than send queries over Do53, the stub resolver
    first sends a probing query to verify that the proxy supports the
    PROXY CONTROL and PROXY SCOPE Options.
-
-
-
-
-
-Homburg                  Expires 6 January 2023                [Page 11]
-
-Internet-Draft                    codcp                        July 2022
-
 
    This request queries "resolver.arpa" for SOA records.  The proxy MUST
    implement this as a Special Use Domain Name.  The actual response is
@@ -643,6 +660,20 @@ Internet-Draft                    codcp                        July 2022
    ANCHORS-P7S, then the application verifies the trust anchor using the
    trust anchor certificate (which needs to come with the application).
 
+
+
+
+
+
+
+
+
+
+Homburg                  Expires 8 January 2023                [Page 12]
+
+Internet-Draft                    codcp                        July 2022
+
+
 8.2.  Server Processing
 
    Proxies are encouraged to cache options that appear in requests under
@@ -664,15 +695,6 @@ Internet-Draft                    codcp                        July 2022
    The proxy MUST implement "resolver.arpa" as a locally served zone.
    Proxies SHOULD respond to all queries with NODATA unless other
    behavior is specified in a different document.
-
-
-
-
-
-Homburg                  Expires 6 January 2023                [Page 12]
-
-Internet-Draft                    codcp                        July 2022
-
 
    If the proxy successfully connects to a recursive resolver and
    receives a reply, or the query is for a special use domain name that
@@ -699,6 +721,15 @@ Internet-Draft                    codcp                        July 2022
    header in the HTTP reply.  The proxy adds a TRUST ANCHOR Option to
    the reply.
 
+
+
+
+
+Homburg                  Expires 8 January 2023                [Page 13]
+
+Internet-Draft                    codcp                        July 2022
+
+
 9.  Connection Between Stub Resolver And Proxy
 
    Absent other configuration, a stub resolver that implements this
@@ -717,18 +748,6 @@ Internet-Draft                    codcp                        July 2022
    configuration methods, such as /etc/resolv.conf.  However, in that
    case the stub resolver MUST make sure that doing so does not violate
    the policy set by the application.
-
-
-
-
-
-
-
-
-Homburg                  Expires 6 January 2023                [Page 13]
-
-Internet-Draft                    codcp                        July 2022
-
 
 10.  Security Considerations
 
@@ -758,6 +777,15 @@ Internet-Draft                    codcp                        July 2022
    IANA has assigned the following DNS response code as an early
    allocation per [RFC7120]:
 
+
+
+
+
+Homburg                  Expires 8 January 2023                [Page 14]
+
+Internet-Draft                    codcp                        July 2022
+
+
     RCODE    Name             Description                   Reference
    -------- ---------------- ----------------------------- -----------
     TBD      BADPROXYPOLICY   Unable to conform to policy   RFC xxxx
@@ -778,15 +806,11 @@ Internet-Draft                    codcp                        July 2022
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
-
-
-
-Homburg                  Expires 6 January 2023                [Page 14]
-
-Internet-Draft                    codcp                        July 2022
-
-
 14.  Informative References
+
+   [RFC1034]  Mockapetris, P., "Domain names - concepts and facilities",
+              STD 13, RFC 1034, DOI 10.17487/RFC1034, November 1987,
+              <https://www.rfc-editor.org/info/rfc1034>.
 
    [RFC1035]  Mockapetris, P., "Domain names - implementation and
               specification", STD 13, RFC 1035, DOI 10.17487/RFC1035,
@@ -811,6 +835,13 @@ Internet-Draft                    codcp                        July 2022
               BCP 152, RFC 5625, DOI 10.17487/RFC5625, August 2009,
               <https://www.rfc-editor.org/info/rfc5625>.
 
+
+
+Homburg                  Expires 8 January 2023                [Page 15]
+
+Internet-Draft                    codcp                        July 2022
+
+
    [RFC6891]  Damas, J., Graff, M., and P. Vixie, "Extension Mechanisms
               for DNS (EDNS(0))", STD 75, RFC 6891,
               DOI 10.17487/RFC6891, April 2013,
@@ -834,13 +865,6 @@ Internet-Draft                    codcp                        July 2022
               "DNSSEC Trust Anchor Publication for the Root Zone",
               RFC 7958, DOI 10.17487/RFC7958, August 2016,
               <https://www.rfc-editor.org/info/rfc7958>.
-
-
-
-Homburg                  Expires 6 January 2023                [Page 15]
-
-Internet-Draft                    codcp                        July 2022
-
 
    [RFC8484]  Hoffman, P. and P. McManus, "DNS Queries over HTTPS
               (DoH)", RFC 8484, DOI 10.17487/RFC8484, October 2018,
@@ -869,28 +893,4 @@ Author's Address
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Homburg                  Expires 6 January 2023                [Page 16]
+Homburg                  Expires 8 January 2023                [Page 16]

--- a/notes/dns-client-proxy.txt
+++ b/notes/dns-client-proxy.txt
@@ -1,0 +1,78 @@
+Abstract
+
+The introduction of many new transport portocols for DNS in recent years
+(DoT, DoH, DoQ) significantly increases the complexity of DNS stub
+resolvers that want to support these protocols. A practical way forward
+is to have a DNS client proxy in the host operating system. This allows
+applications to communicate using Do53 and still get the privacy
+benefit from using more secure protocols over the internet. However,
+such a setup leaves the application with no control over which transport
+the proxy uses. This document introduces EDNS options that allow a
+stub resolver to request certain transport and allow the proxy to report
+capabilities and actual transports that are available.
+
+
+Introduction
+
+<repeat and extend abstract>
+
+For short-lived applications, the overhead of setting a DoH connection
+is quite high if the application only needs to send a few DNS requests.
+
+A local proxy may provide some benefit to short-lived applications by
+caching results. In particular if the system uses a so called 'public
+DNS resolver'. In general we assume that the cache is tagged according
+to the source of a reply and the transport it is received on. 
+
+With respect to DNSSEC, we assume that an application that needs
+DNSSEC validation, for example, for DANE validation or SSHFP, will 
+perform the DNSSEC validation within the application itself and does not
+trust the proxy. The proxy can ofcourse do DNSSEC validation as well.
+Important however, is that an untrusted proxy cannot provide an application
+with a traditional (unsigned) trust anchor.
+
+For the transport configuration we expect three levels of details. The
+first is a choice between anythings goes, optimistic encryption and
+authenticated encryption. The second level is where the application also
+specifies the names and/or IP addresses of upstream resolvers. The
+third level is where the application also specifies which transports
+(Do53, DoT, DoH, DoQ) are allowed to be used. A final transport parameter
+is the outgoing interface that is to be used.
+
+For authentication we can have a mix of PKI and DANE. Options are one of 
+the two and not the other, both or one of the two.
+
+In a reponse, the proxy reports the interface, resolver, and transport
+used.
+
+The proxy can provide an application with a signed trust anchor.
+
+Description
+
+The most basic option has 5 flags:
+- force unencrypted (Do53)
+- at least optimistic encryption (DoT, DoH does not allow optimistic
+  encryption, what about DoQ)
+- authenticated encryption 
+- authenticate using PKI only
+- authenticate using DANE only
+
+An extended option has these flags and has per transport (Do53, DoT, DoH,
+DoQ) flags for
+- allow this transport
+- avoid this transport 
+- require this transport
+
+For future transports (which are unknown the application) we can have:
+- allow future transports
+- avoid future transports
+(require future transports, which is a weird thing to do, could be achieved
+by avoiding all known transports)
+
+Then we can extend this even further by adding an IP address and/or a name.
+(open question, if we have only an IP address, can we figure out the name?)
+If we have only a name, then DNS resolution with implicit resolvers will be
+used to resolve the name. If we have a name and an address, connect to
+the address and use the name for authentication.
+
+

--- a/notes/dns-client-proxy.txt
+++ b/notes/dns-client-proxy.txt
@@ -71,20 +71,20 @@ Table of Contents
    3.  Key Words . . . . . . . . . . . . . . . . . . . . . . . . . .   4
    4.  Description . . . . . . . . . . . . . . . . . . . . . . . . .   4
    5.  PROXY CONTROL OPTION  . . . . . . . . . . . . . . . . . . . .   4
-   6.  PROXY SCOPE OPTION  . . . . . . . . . . . . . . . . . . . . .   7
-   7.  TRUST ANCHOR OPTION . . . . . . . . . . . . . . . . . . . . .   8
+   6.  PROXY SCOPE OPTION  . . . . . . . . . . . . . . . . . . . . .   8
+   7.  TRUST ANCHOR OPTION . . . . . . . . . . . . . . . . . . . . .   9
    8.  Protocol Specification  . . . . . . . . . . . . . . . . . . .   9
-   9.  Client Processing . . . . . . . . . . . . . . . . . . . . . .   9
+   9.  Client Processing . . . . . . . . . . . . . . . . . . . . . .  10
      9.1.  Probing . . . . . . . . . . . . . . . . . . . . . . . . .  10
      9.2.  Trust Anchor  . . . . . . . . . . . . . . . . . . . . . .  10
    10. Server Processing . . . . . . . . . . . . . . . . . . . . . .  11
-   11. Connection Between Stub Resolver And Proxy  . . . . . . . . .  11
+   11. Connection Between Stub Resolver And Proxy  . . . . . . . . .  12
    12. Security Considerations . . . . . . . . . . . . . . . . . . .  12
    13. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  12
    14. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  12
    15. Normative References  . . . . . . . . . . . . . . . . . . . .  12
-   16. Informative References  . . . . . . . . . . . . . . . . . . .  12
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  13
+   16. Informative References  . . . . . . . . . . . . . . . . . . .  13
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  14
 
 1.  Definitions
 
@@ -152,16 +152,16 @@ Internet-Draft                    codcp                        June 2022
    an application with a traditional (unsigned) trust anchor.
 
    For the transport configuration we expect three levels of details.
-   The first is a choice between anythings goes, unauthenticated
-   encryption and authenticated encryption.  The second level is where
-   the application also specifies the names and/or IP addresses of
-   upstream resolvers.  The third level is where the application also
-   specifies which transports (Do53, DoT, DoH, DoQ) are allowed to be
-   used.  A final transport parameter is the outgoing interface that is
-   to be used.
+   The first is a choice between requiring authenticated encryption,
+   also allowing unauthenticated encryption or doing opportunistic
+   encryption on an best effort basis.  The second level is where the
+   application also specifies the names and/or IP addresses of upstream
+   resolvers.  The third level is where the application also specifies
+   which transports (Do53, DoT, DoH, DoQ) are allowed to be used.  A
+   final transport parameter is the outgoing interface that is to be
+   used.
 
-   For authentication we can have a mix of PKI and DANE.  Options are
-   one of the two and not the other, both or one of the two.
+
 
 
 
@@ -169,6 +169,9 @@ Homburg                  Expires 5 December 2022                [Page 3]
 
 Internet-Draft                    codcp                        June 2022
 
+
+   For authentication we can have a mix of PKI and DANE.  Options are
+   one of the two and not the other, both or one of the two.
 
    A poorly constructed DNS client proxy may forward DNS packets without
    properly handling of EDNS(0) options.  To detect and prevent this, we
@@ -213,9 +216,6 @@ Internet-Draft                    codcp                        June 2022
    DNSSEC trust anchor signed by IANA.
 
 5.  PROXY CONTROL OPTION
-
-
-
 
 
 
@@ -351,7 +351,10 @@ Internet-Draft                    codcp                        June 2022
    should be used or not.  For each of 5 different transports (Do53,
    DoT, DoH with ALPN h2, DoH with ALPN h3, DoQ) there is a flag to
    allow (A53,AT,AH2,AH3,AQ) or disallow (D53,DT,DH2,DH3,DQ) the use of
-   the transport.  There is space to add more transports later.
+   the transport.  There is space to add more transports later.  Note
+   that setting the A flags and the D flag for a protocol (for example,
+   setting both the A53 and the D53 flags) is not allowed and a proxy
+   SHOULD reject such a request.
 
    To future proof applications, there is a single flag DO, that
    disallows transports that are not explicitly listed.  With this flag
@@ -359,6 +362,16 @@ Internet-Draft                    codcp                        June 2022
    the application has to explicitly list which transports can be used.
    For example, by setting only DO and AT, the application forces the
    use of DoT.
+
+   When DO = 0:
+
+   *  all transports are in the pool of potentially usable transports
+   *  D53, DT, DH2, DH3 and DQ remove those transports from the pool
+
+   When DO = 1:
+
+   *  no transports are in the pool of potentially usable transports
+   *  A53, AT, AH2, AH3 and AQ add those transports to the pool
 
    Finally, an application can specify its own resolvers or rely on the
    resolvers that are know to the proxy.  If ADN Length and Addr Length
@@ -374,25 +387,22 @@ Internet-Draft                    codcp                        June 2022
    proxy will use the specified addresses and use the name for
    authentication.
 
-   To simplify the encoding of the option, an option with addresses will
-   have either IPv4 or IPv6 addresses.  If the application wants to
-   specify both IPv4 and IPv6 address for a certain authentication-
-   domain-name then it has to include two options.
-
-   When present, Service Parameters specify how to connect.  Otherwise
-   it is up to the proxy to try various possibilities.
-
-6.  PROXY SCOPE OPTION
-
-
-
-
 
 
 Homburg                  Expires 5 December 2022                [Page 7]
 
 Internet-Draft                    codcp                        June 2022
 
+
+   To simplify the encoding of the option, an option with addresses will
+   have either IPv4 or IPv6 addresses.  If the application wants to
+   specify both IPv4 and IPv6 addresses for a certain authentication-
+   domain-name then it has to include two options.
+
+   When present, Service Parameters specify how to connect.  Otherwise
+   it is up to the proxy to try various possibilities.
+
+6.  PROXY SCOPE OPTION
 
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
     0: |                          OPTION-CODE                          |
@@ -432,16 +442,6 @@ Internet-Draft                    codcp                        June 2022
    The purpose of this option is to deal with badly implemented proxies
    that forward DNS traffic without first removing any EDNS(0) options.
    The option requests the DNS proxy that processes the option to report
-   the scope of the source address.  The application can specify that
-   the connection between the stub resolver and the proxy should have,
-   for example, at most host local scope.
-
-7.  TRUST ANCHOR OPTION
-
-
-
-
-
 
 
 
@@ -449,6 +449,12 @@ Homburg                  Expires 5 December 2022                [Page 8]
 
 Internet-Draft                    codcp                        June 2022
 
+
+   the scope of the source address.  The application can specify that
+   the connection between the stub resolver and the proxy should have,
+   for example, at most host local scope.
+
+7.  TRUST ANCHOR OPTION
 
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
     0: |                          OPTION-CODE                          |
@@ -489,14 +495,8 @@ Internet-Draft                    codcp                        June 2022
 
 8.  Protocol Specification
 
-9.  Client Processing
 
-   A stub resolver that wishes to use the PROXY CONTROL Option includes
-   the option in all outgoing DNS requests that require privacy.  The
-   option should be initialized according to the needs of the
-   application.  In addition the PROXY SCOPE Option can be added.  In
-   requests, the Scope field is set to largest scope that the
-   application can accept.
+
 
 
 
@@ -505,6 +505,15 @@ Homburg                  Expires 5 December 2022                [Page 9]
 
 Internet-Draft                    codcp                        June 2022
 
+
+9.  Client Processing
+
+   A stub resolver that wishes to use the PROXY CONTROL Option includes
+   the option in all outgoing DNS requests that require privacy.  The
+   option should be initialized according to the needs of the
+   application.  In addition the PROXY SCOPE Option can be added.  In
+   requests, the Scope field is set to largest scope that the
+   application can accept.
 
    If the stub resolver receives a reply without a PROXY CONTROL Option
    included in the reply, then stub resolver has to assume that traffic
@@ -541,15 +550,6 @@ Internet-Draft                    codcp                        June 2022
    signature over the trust anchor.  For this reason, it makes sense to
    let the proxy cache this information.
 
-   If the local operating system does not provide a DNSSEC trust anchor,
-   then the application can ask the proxy.  The stub resolver adds the
-   TRUST ANCHOR Option with ANCHORS-XML-LENGTH and ANCHORS-P7S-LENGTH.
-   If the proxy returns both an ANCHORS-XML and an ANCHORS-P7S, then the
-   application verifies the trust anchor using the trust anchor
-   certificate (which needs to come with the application).
-
-
-
 
 
 
@@ -561,6 +561,13 @@ Homburg                  Expires 5 December 2022               [Page 10]
 
 Internet-Draft                    codcp                        June 2022
 
+
+   If the local operating system does not provide a DNSSEC trust anchor,
+   then the application can ask the proxy.  The stub resolver adds the
+   TRUST ANCHOR Option with ANCHORS-XML-LENGTH and ANCHORS-P7S-LENGTH.
+   If the proxy returns both an ANCHORS-XML and an ANCHORS-P7S, then the
+   application verifies the trust anchor using the trust anchor
+   certificate (which needs to come with the application).
 
 10.  Server Processing
 
@@ -603,13 +610,6 @@ Internet-Draft                    codcp                        June 2022
    documents can be cache.  A simple solution is to take the Expires
    header in the HTTP reply.
 
-11.  Connection Between Stub Resolver And Proxy
-
-   Absent other configuration, a stub resolver that implements this
-   standard SHOULD connect to the proxy using Do53 and as remote address
-   either ::1 or 127.0.0.1.  In particular, the stub resolver SHOULD
-   avoid using name servers listed in files such as /etc/resolv.conf.
-
 
 
 
@@ -618,7 +618,14 @@ Homburg                  Expires 5 December 2022               [Page 11]
 Internet-Draft                    codcp                        June 2022
 
 
-   There reason for this is to simplify the integration of local DNS
+11.  Connection Between Stub Resolver And Proxy
+
+   Absent other configuration, a stub resolver that implements this
+   standard SHOULD connect to the proxy using Do53 and as remote address
+   either ::1 or 127.0.0.1.  In particular, the stub resolver SHOULD
+   avoid using name servers listed in files such as /etc/resolv.conf.
+
+   The reason for this is to simplify the integration of local DNS
    proxies in existing environments.  If the stub resolver ignores /etc/
    resolv.conf then the proxy can use that information to connect to
    recursive resolvers.
@@ -656,6 +663,17 @@ Internet-Draft                    codcp                        June 2022
 
 15.  Normative References
 
+
+
+
+
+
+
+Homburg                  Expires 5 December 2022               [Page 12]
+
+Internet-Draft                    codcp                        June 2022
+
+
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
               DOI 10.17487/RFC2119, March 1997,
@@ -666,13 +684,6 @@ Internet-Draft                    codcp                        June 2022
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
 16.  Informative References
-
-
-
-Homburg                  Expires 5 December 2022               [Page 12]
-
-Internet-Draft                    codcp                        June 2022
-
 
    [RFC1035]  Mockapetris, P., "Domain names - implementation and
               specification", STD 13, RFC 1035, DOI 10.17487/RFC1035,
@@ -711,6 +722,14 @@ Internet-Draft                    codcp                        June 2022
               RFC 7958, DOI 10.17487/RFC7958, August 2016,
               <https://www.rfc-editor.org/info/rfc7958>.
 
+
+
+
+Homburg                  Expires 5 December 2022               [Page 13]
+
+Internet-Draft                    codcp                        June 2022
+
+
    [RFC8484]  Hoffman, P. and P. McManus, "DNS Queries over HTTPS
               (DoH)", RFC 8484, DOI 10.17487/RFC8484, October 2018,
               <https://www.rfc-editor.org/info/rfc8484>.
@@ -722,28 +741,9 @@ Internet-Draft                    codcp                        June 2022
 
 Author's Address
 
-
-
-
-Homburg                  Expires 5 December 2022               [Page 13]
-
-Internet-Draft                    codcp                        June 2022
-
-
    Philip Homburg
 
    Email: philip@nlnetlabs.nl
-
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/notes/dns-client-proxy.txt
+++ b/notes/dns-client-proxy.txt
@@ -3,9 +3,9 @@
 
 
 ADD                                                         P.C. Homburg
-Internet-Draft                                               7 June 2022
+Internet-Draft                                               5 July 2022
 Intended status: Standards Track                                        
-Expires: 9 December 2022
+Expires: 6 January 2023
 
 
                  Control Options For DNS Client Proxies
@@ -40,7 +40,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 9 December 2022.
+   This Internet-Draft will expire on 6 January 2023.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Homburg                  Expires 9 December 2022                [Page 1]
+Homburg                  Expires 6 January 2023                 [Page 1]
 
-Internet-Draft                    codcp                        June 2022
+Internet-Draft                    codcp                        July 2022
 
 
    Please review these documents carefully, as they describe your rights
@@ -71,20 +71,20 @@ Table of Contents
    3.  Key Words . . . . . . . . . . . . . . . . . . . . . . . . . .   4
    4.  Description . . . . . . . . . . . . . . . . . . . . . . . . .   4
    5.  PROXY CONTROL OPTION  . . . . . . . . . . . . . . . . . . . .   5
-   6.  PROXY SCOPE OPTION  . . . . . . . . . . . . . . . . . . . . .   8
-   7.  TRUST ANCHOR OPTION . . . . . . . . . . . . . . . . . . . . .   9
-   8.  Protocol Specification  . . . . . . . . . . . . . . . . . . .  10
-   9.  Client Processing . . . . . . . . . . . . . . . . . . . . . .  10
-     9.1.  Probing . . . . . . . . . . . . . . . . . . . . . . . . .  11
-     9.2.  Trust Anchor  . . . . . . . . . . . . . . . . . . . . . .  11
-   10. Server Processing . . . . . . . . . . . . . . . . . . . . . .  12
-   11. Connection Between Stub Resolver And Proxy  . . . . . . . . .  12
-   12. Security Considerations . . . . . . . . . . . . . . . . . . .  13
-   13. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  13
-   14. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  13
-   15. Normative References  . . . . . . . . . . . . . . . . . . . .  13
-   16. Informative References  . . . . . . . . . . . . . . . . . . .  13
-   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  15
+   6.  PROXY SCOPE OPTION  . . . . . . . . . . . . . . . . . . . . .   9
+   7.  TRUST ANCHOR OPTION . . . . . . . . . . . . . . . . . . . . .  10
+   8.  Protocol Specification  . . . . . . . . . . . . . . . . . . .  11
+     8.1.  Client Processing . . . . . . . . . . . . . . . . . . . .  11
+       8.1.1.  Probing . . . . . . . . . . . . . . . . . . . . . . .  11
+       8.1.2.  Trust Anchor  . . . . . . . . . . . . . . . . . . . .  12
+     8.2.  Server Processing . . . . . . . . . . . . . . . . . . . .  12
+   9.  Connection Between Stub Resolver And Proxy  . . . . . . . . .  13
+   10. Security Considerations . . . . . . . . . . . . . . . . . . .  14
+   11. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
+   12. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  14
+   13. Normative References  . . . . . . . . . . . . . . . . . . . .  14
+   14. Informative References  . . . . . . . . . . . . . . . . . . .  15
+   Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  16
 
 1.  Definitions
 
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Homburg                  Expires 9 December 2022                [Page 2]
+Homburg                  Expires 6 January 2023                 [Page 2]
 
-Internet-Draft                    codcp                        June 2022
+Internet-Draft                    codcp                        July 2022
 
 
       described in I.D.ietf-quic-http (expired draft)
@@ -119,6 +119,8 @@ Internet-Draft                    codcp                        June 2022
    Interface Name  A name that identifies a network interface as
       described in [RFC3493].  In addition, an interface index converted
       to a decimal number is also consider an interface name.
+
+   PKIX  Public-Key Infrastructure using X.509.  See [RFC5280]
 
 2.  Introduction
 
@@ -163,14 +165,12 @@ Internet-Draft                    codcp                        June 2022
 
 
 
-
-
-Homburg                  Expires 9 December 2022                [Page 3]
+Homburg                  Expires 6 January 2023                 [Page 3]
 
-Internet-Draft                    codcp                        June 2022
+Internet-Draft                    codcp                        July 2022
 
 
-   For authentication we can have a mix of PKI and DANE.  Options are
+   For authentication we can have a mix of PKIX and DANE.  Options are
    one of the two and not the other, both or one of the two.
 
    In a response, the proxy reports the interface, resolver, and
@@ -181,27 +181,24 @@ Internet-Draft                    codcp                        June 2022
    what could happen is that an application sends a privacy sensitive
    request to local proxy, expecting the proxy upstream connection to be
    encrypted.  However, a simple proxy may just forward the request
-   unencrypted to another proxy, for exmaple, one in a CPE that does
+   unencrypted to another proxy, for example, one in a CPE that does
    implement the protocol described in this document.  So what could
    happen is that the request travels unencrypted over a local lan, or
    if proxies deeper in the network support this protocol, even further
    without the application noticing that something is wrong.
 
-   To handle this case, we introduce an option that limits the
-   connection between the stub resolver and the proxy to host-local,
-   link-local, or site-local.  The requirement on a conforming DNS
-   client proxy is to check where a request comes from and compare this
-   to the option in the request (if any).  An error is returned if there
-   is a mismatch.
+   To handle this case, we introduce an option where the proxy reports
+   whether the connection between the stub resolver and the proxy is
+   host-local, link-local, or site-local or global.
 
    In the ideal case, the host operating system provides applications
    with a secure way to access a DNSSEC trust anchor that is maintained
    according to [RFC5011].  However in situations where this is not the
    case, an application can fall back to [RFC7958].  However, for short
-   lived processes, there is considerable overhead in issuing to HTTP(S)
-   requests to data.iana.org to obtain the trust anchor XML file and the
-   signature over the trust anchor.  For this reason, it makes sense to
-   let the proxy cache this information.
+   lived processes, there is considerable overhead in issuing two
+   HTTP(S) requests to data.iana.org to obtain the trust anchor XML file
+   and the signature over the trust anchor.  For this reason, it makes
+   sense to let the proxy cache this information.
 
 3.  Key Words
 
@@ -213,25 +210,27 @@ Internet-Draft                    codcp                        June 2022
 
 4.  Description
 
-   This document introduces the new EDNS(0) options, and one new
+   This document introduces three new EDNS(0) options, and one new
    response code.  This first option, called PROXY CONTROL Option,
    specifies which transports a proxy should use to connect to a
    recursive resolver.
 
-
-
-
-Homburg                  Expires 9 December 2022                [Page 4]
-
-Internet-Draft                    codcp                        June 2022
-
-
-   The second option, called PROXY SCOPE Option, controls the IP address
+   The second option, called PROXY SCOPE Option, reports the IP address
    scope of the connection between the application's stub resolver and
    the proxy.
 
+
+
+Homburg                  Expires 6 January 2023                 [Page 4]
+
+Internet-Draft                    codcp                        July 2022
+
+
    Finally, the TRUST ANCHOR Option, provides the application with a
    DNSSEC trust anchor signed by IANA.
+
+   The BADPROXYPOLICY error is returned the proxy cannot meet the
+   requirements in a PROXY CONTROL Option or the option is malformed.
 
 5.  PROXY CONTROL OPTION
 
@@ -240,7 +239,7 @@ Internet-Draft                    codcp                        June 2022
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
     2: |                         OPTION-LENGTH                         |
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-    4: | U |UA | A | P | D |DO |                     Z                 |
+    4: | U |UA | A | P | D |DD |                     Z                 |
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
     6: |A53|D53|AT |DT |AH2|DH2|AH3|DH3|AQ |DQ |         Z             |
        +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -267,35 +266,34 @@ Internet-Draft                    codcp                        June 2022
       To be decided
 
    OPTION-LENGTH
-      Lenght of this option excluding the OPTION-CODE and OPTION-LENGTH
+      Length of this option excluding the OPTION-CODE and OPTION-LENGTH
       fields
 
    U 
       force the use of unencrypted communication (Do53)
 
    UA
-
-
-
-Homburg                  Expires 9 December 2022                [Page 5]
-
-Internet-Draft                    codcp                        June 2022
-
-
       require unauthenticated encryption
+
+
+
+Homburg                  Expires 6 January 2023                 [Page 5]
+
+Internet-Draft                    codcp                        July 2022
+
 
    A 
       require authenticated encryption
 
    P 
-      authenticate using a PKI certificate
+      authenticate using a PKIX certificate
 
    D 
       authenticate using DANE
 
-   DO
-      disallow other transports (transports that are not explicitly
-      listed)
+   DD
+      by default disallow other transports (transports that are not
+      explicitly listed)
 
    A53,AT,AH2,AH3,AQ
       allow respectively Do53, DoT, DoH H2, DoH H3, DoQ
@@ -307,7 +305,8 @@ Internet-Draft                    codcp                        June 2022
       reserved, MUST be zero when sending, MUST be ignored when received
 
    Addr Type
-      Type of addresses, IPv4 or IPv6
+      Type of addresses, The value 0 if no addresses are included, the
+      value 1 for IPv4, and the value 2 for IPv6.
 
    Addr Length
       length of the addresses in octets.  Must be a multiple of 4 for
@@ -321,7 +320,8 @@ Internet-Draft                    codcp                        June 2022
       length of Domain Name.  Zero if there is no Domain Name
 
    Domain Name
-      domain name for authentication or resolving IP addresses
+      domain name for authentication or resolving IP addresses.  The
+      domain name is encoding in uncompressed DNS wire format.
 
    SvcParams Length
       length of SvcParams.  Zero if there are no service parameters
@@ -333,9 +333,9 @@ Internet-Draft                    codcp                        June 2022
 
 
 
-Homburg                  Expires 9 December 2022                [Page 6]
+Homburg                  Expires 6 January 2023                 [Page 6]
 
-Internet-Draft                    codcp                        June 2022
+Internet-Draft                    codcp                        July 2022
 
 
    Interface Name Length
@@ -346,17 +346,69 @@ Internet-Draft                    codcp                        June 2022
 
    This option is designed to give control over what level of detail it
    wants to specify.  The first 5 flags (U, UA, A, P, and D) give
-   generate requirements for properties of DNS transports that are used
-   by the client proxy.  The U flag specifies no encryption, the UA
-   flag, at least unauthenticated encryption and the A flag require
-   authenticated encryptions.  With the U, UA, and A flags clear, an
-   effort is made to reach authenticated encryption, if that fails
-   unauthenticated encryption and if that fails, fall back to an
-   unencrypted transport.  The P and D flags allow the application to
-   require a specific authentication mechanism (PKI or DANE).  When both
-   flags are set, PKI and DANE are required together.  If no flags are
-   set, are least one of the two has to succeed if authenticated
-   encryption is required.
+   general requirements for properties of DNS transports that are used
+   by the client proxy.  The U, UA, and A flags are mutually exclusive.
+   If more than one flag is set, the proxy SHOULD return a
+   BADPROXYPOLICY error.  There are four possibilities:
+
+   U = 0, UA = 0, A = 0  An effort is made to reach authenticated
+      encryption, if that fails, unauthenticated encryption is tried.
+      If that also fails, the proxy resorts to an unencrypted transport.
+      It is an error if either or both of the P or D flags is set and
+      the proxy SHOULD return a BADPROXYPOLICY error.
+
+   U = 1, UA = 0, A = 0  The proxy only tries only unencrypted
+      transports.  It is an error if either or both of the P or D flags
+      is set and the proxy SHOULD return a BADPROXYPOLICY error.
+
+   U = 0, UA = 1, A = 0  An effort is made to reach authenticated
+      encryption, if that fails, unauthenticated encryption is tried.
+      It is an error if either or both of the P or D flags is set and
+      the proxy SHOULD return a BADPROXYPOLICY error.
+
+   U = 0, UA = 0, A = 1  The proxy only tries authenticated encryption.
+      The P and D flags can be set to control which authentication
+      mechanism has to be used.
+
+   The P and D flags allow the application to require a specific
+   authentication mechanism (PKIX or DANE).  The meaning of the flags is
+   the following:
+
+   P = 0, D = 0  At least one of the two mechanisms has to validate for
+      authenticated encryption to succeed.
+
+   P = 1, D = 0  PKIX validation has to succeed, the status of DANE
+      validation is ignored.
+
+   P = 0, D = 1  A DANE record has to be present and be DNSSEC valid.  A
+
+
+
+
+
+
+
+
+Homburg                  Expires 6 January 2023                 [Page 7]
+
+Internet-Draft                    codcp                        July 2022
+
+
+      DANE record has a Certificate Usage Field.  For some values of
+      this field (the values zero and one), DANE requires PKIX
+      validation.  In those cases, PKIX validation is also required
+      according to the DANE specifications.  For the values two and
+      three, DANE does not require PKIX and because the P flag is zero,
+      the result of PKIX validation has to be ignored.
+
+   P = 1, D = 1  Both PKIX and DANE are required together.  For PKIX,
+      this means that PKIX validation has to succeed.  For DANE it means
+      that a DANE record has to be present and be DNSSEC valid.
+      Validation using the DANE record has to succeed.
+
+   Note that these two flags can only be used in combination with the A
+   flag.  The proxy SHOULD return a BADPROXYPOLICY error if either or
+   both of the P or D flags is set and the A flag is clear.
 
    The next flags provide more detailed control over which transports
    should be used or not.  For each of 5 different transports (Do53,
@@ -367,45 +419,43 @@ Internet-Draft                    codcp                        June 2022
    setting both the A53 and the D53 flags) is not allowed and a proxy
    SHOULD reject such a request.
 
-   To future proof applications, there is a single flag DO, that
-   disallows transports that are not explicitly listed.  With this flag
-   clear, the application allows future transports.  With the flag set,
-   the application has to explicitly list which transports can be used.
-   For example, by setting only DO and AT, the application forces the
-   use of DoT.
+   To future proof applications, there is a single flag DD, that by
+   default disallows transports that are not explicitly listed.  With
+   this flag clear, the application allows all transports that are not
+   explicitly disallowed (including future transports).  With the flag
+   set, the application has to explicitly list which transports can be
+   used.  For example, by setting only DD and AT, the application forces
+   the use of DoT.
 
-   When DO = 0:
+   When DD = 0:
 
    *  all transports are in the pool of potentially usable transports
    *  D53, DT, DH2, DH3 and DQ remove those transports from the pool
 
-   When DO = 1:
+   When DD = 1:
 
    *  no transports are in the pool of potentially usable transports
    *  A53, AT, AH2, AH3 and AQ add those transports to the pool
 
-
-
-
-
-
-Homburg                  Expires 9 December 2022                [Page 7]
-
-Internet-Draft                    codcp                        June 2022
-
-
    Finally, an application can specify its own resolvers or rely on the
-   resolvers that are know to the proxy.  If ADN Length and Addr Length
-   are both zero, then the application requests to resolvers known to
+   resolvers that are known to the proxy.  If ADN Length and Addr Length
+   are both zero, then the application requests the resolvers known to
    the proxy.  [Note: it is unclear at the moment what to do with any
    Service Parameters]
+
+
+
+Homburg                  Expires 6 January 2023                 [Page 8]
+
+Internet-Draft                    codcp                        July 2022
+
 
    If the application specifies only an authentication-domain-name then
    the proxy is expected to resolve the name to addresses.  If only
    addresses are specified then the proxy assumes that no name is known
-   (though a PKI certificate may include an address literal in the
+   (though a PKIX certificate may include an address literal in the
    subjectAltName).  If both a name and address are specified then the
-   proxy will use the specified addresses and use the name for
+   proxy will use the specified address and use the name for
    authentication.
 
    To simplify the encoding of the option, an option with addresses will
@@ -427,28 +477,16 @@ Internet-Draft                    codcp                        June 2022
    be an interface index expressed as a decimal string.
 
    When present, Service Parameters specify how to connect.  Otherwise
-   it is up to the proxy to try various possibilities.
+   it is up to the proxy to try various possibilities.  For Service
+   Parameters, the values of the ipv4hint and ipv6hint fields are
+   ignored.  Addresses can only be specified using the addresses field
+   in the PROXY CONTROL Option.
 
    Associated with this option is a new error, BADPROXYPOLICY.  When a
-   proxy cannot meet the requirement in a PROXY CONTROL option, it
-   returns this error along with a PROXY CONTROL option that lists what
-   it can do.
+   proxy cannot meet the requirements in a PROXY CONTROL Option or the
+   option is malformed, it returns this error.
 
 6.  PROXY SCOPE OPTION
-
-
-
-
-
-
-
-
-
-
-Homburg                  Expires 9 December 2022                [Page 8]
-
-Internet-Draft                    codcp                        June 2022
-
 
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
     0: |                          OPTION-CODE                          |
@@ -460,6 +498,13 @@ Internet-Draft                    codcp                        June 2022
 
    OPTION-CODE
       To be decided
+
+
+
+Homburg                  Expires 6 January 2023                 [Page 9]
+
+Internet-Draft                    codcp                        July 2022
+
 
    OPTION-LENGTH
       Length of this option excluding the OPTION-CODE and OPTION-LENGTH
@@ -485,26 +530,12 @@ Internet-Draft                    codcp                        June 2022
 
                                    Table 1
 
-   The purpose of this option is to deal with badly implemented proxies
-   that forward DNS traffic without first removing any EDNS(0) options.
-   The option requests the DNS proxy that processes the option to report
-   the scope of the source address.  The application can specify that
-   the connection between the stub resolver and the proxy should have,
-   for example, at most host local scope.
+   The purpose of this option is to deal with proxies that forward DNS
+   traffic without first removing any EDNS(0) options.  The option
+   requests the DNS proxy that processes the option to report the scope
+   of the source address.
 
 7.  TRUST ANCHOR OPTION
-
-
-
-
-
-
-
-
-Homburg                  Expires 9 December 2022                [Page 9]
-
-Internet-Draft                    codcp                        June 2022
-
 
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
     0: |                          OPTION-CODE                          |
@@ -523,10 +554,18 @@ Internet-Draft                    codcp                        June 2022
    where
 
    OPTION-CODE
+
+
+
+Homburg                  Expires 6 January 2023                [Page 10]
+
+Internet-Draft                    codcp                        July 2022
+
+
       To be decided
 
    OPTION-LENGTH
-      Lenght of this option excluding the OPTION-CODE and OPTION-LENGTH
+      Length of this option excluding the OPTION-CODE and OPTION-LENGTH
       fields
 
    ANCHORS-XML-LENGTH
@@ -545,22 +584,13 @@ Internet-Draft                    codcp                        June 2022
 
 8.  Protocol Specification
 
-9.  Client Processing
+8.1.  Client Processing
 
    A stub resolver that wishes to use the PROXY CONTROL Option includes
    the option in all outgoing DNS requests that require privacy.  The
    option should be initialized according to the needs of the
    application.  In addition the PROXY SCOPE Option can be added.  In
-   requests, the Scope field is set to largest scope that the
-   application can accept.
-
-
-
-
-Homburg                  Expires 9 December 2022               [Page 10]
-
-Internet-Draft                    codcp                        June 2022
-
+   requests, the Scope field is set to undefined.
 
    If the stub resolver receives a reply without a PROXY CONTROL Option
    included in the reply, then stub resolver has to assume that traffic
@@ -568,57 +598,52 @@ Internet-Draft                    codcp                        June 2022
    Option implies a global scope.
 
    If the stub resolver receives a BADPROXYPOLICY error then the proxy
-   was unable to meet the requirements of the option(s).  In the reply,
-   the proxy modifies the options to show what it can do.
+   was unable to meet the requirements of the PROXY CONTROL Option.
 
-9.1.  Probing
+8.1.1.  Probing
 
    In cases where the stub resolver expects a local DNS proxy, or where
    the stub resolver has (a limited) fall back to more private
    transports, or when the security policy of the application is such
    that is better to fail than send queries over Do53, the stub resolver
    first sends a probing query to verify that the proxy supports the
-   PROXY CONTROL and PROXY SCOPE options.
+   PROXY CONTROL and PROXY SCOPE Options.
 
-   This request queries "resolver.arpa".  The proxy MUST implement this
-   as a Special Use Domain Name.  The actual response is not important.
-   The important part is that the proxy returns PROXY CONTROL and PROXY
-   SCOPE options as described in this document and optionally sets the
-   response code to BADPROXYPOLICY specified policy.
 
-9.2.  Trust Anchor
+
+
+
+Homburg                  Expires 6 January 2023                [Page 11]
+
+Internet-Draft                    codcp                        July 2022
+
+
+   This request queries "resolver.arpa" for SOA records.  The proxy MUST
+   implement this as a Special Use Domain Name.  The actual response is
+   not important.  The important part is that the proxy returns PROXY
+   CONTROL and PROXY SCOPE Options as described in this document or sets
+   the response code to BADPROXYPOLICY if it cannot meet specified
+   policy.
+
+8.1.2.  Trust Anchor
 
    In the ideal case, the host operating system provides applications
    with a secure way to access a DNSSEC trust anchor that is maintained
    according to [RFC5011].  However in situations where this is not the
    case, an application can fall back to [RFC7958].  However, for short
-   lived processes, there is considerable overhead in issuing to HTTP(S)
-   requests to data.iana.org to obtain the trust anchor XML file and the
-   signature over the trust anchor.  For this reason, it makes sense to
-   let the proxy cache this information.
+   lived processes, there is considerable overhead in issuing two
+   HTTP(S) requests to data.iana.org to obtain the trust anchor XML file
+   and the signature over the trust anchor.  For this reason, it makes
+   sense to let the proxy cache this information.
 
    If the local operating system does not provide a DNSSEC trust anchor,
    then the application can ask the proxy.  The stub resolver adds the
-   TRUST ANCHOR Option with ANCHORS-XML-LENGTH and ANCHORS-P7S-LENGTH.
-   If the proxy returns both an ANCHORS-XML and an ANCHORS-P7S, then the
-   application verifies the trust anchor using the trust anchor
-   certificate (which needs to come with the application).
+   TRUST ANCHOR Option with ANCHORS-XML-LENGTH and ANCHORS-P7S-LENGTH
+   set to zero.  If the proxy returns both an ANCHORS-XML and an
+   ANCHORS-P7S, then the application verifies the trust anchor using the
+   trust anchor certificate (which needs to come with the application).
 
-
-
-
-
-
-
-
-
-
-Homburg                  Expires 9 December 2022               [Page 11]
-
-Internet-Draft                    codcp                        June 2022
-
-
-10.  Server Processing
+8.2.  Server Processing
 
    Proxies are encouraged to cache options that appear in requests under
    the assumption that a stub resolver will send multiple requests.  If
@@ -634,21 +659,35 @@ Internet-Draft                    codcp                        June 2022
 
    If the proxy cannot obtain a connection to a recursive resolver in a
    way that matches the provided policy, then the proxy sets the
-   BADPROXYPOLICY response code in the reply.  In addition the proxy
-   SHOULD try to find at least one connection to a recursive resolver.
-   If the proxy did not find an alternative connection to a recursive
-   resolver (also if it didn't try) then the proxy includes a PROXY
-   CONTROL Option with all flags set to zero, and with ADN Length, Addr
-   Length, and SvcParams Length set to zero as well.
+   BADPROXYPOLICY response code in the reply.
 
-   If the proxy does have one or more alternative connections to
-   recursive resolvers then the proxy generates options with the
-   properties of those connection, with a maximum of three connections.
+   The proxy MUST implement "resolver.arpa" as a locally served zone.
+   Proxies SHOULD respond to all queries with NODATA unless other
+   behavior is specified in a different document.
+
+
+
+
+
+Homburg                  Expires 6 January 2023                [Page 12]
+
+Internet-Draft                    codcp                        July 2022
+
+
+   If the proxy successfully connects to a recursive resolver and
+   receives a reply, or the query is for a special use domain name that
+   is handled internally in the proxy, then the proxy add a PROXY
+   CONTROL Options dat details the connection to the recursive resolver
+   (i.e., the U, UA, or A flag depending on encryption and
+   authentication, P and or D for authenticated connections, A53, AT,
+   AH2, AH3, or AQ depending on the transport (or none of those for a
+   future transport).  Furthermore the proxy includes the address it
+   connected to, the Domain Name if known, any Service Parameters and
+   the outgoing interface name if known.
 
    If the proxy finds a PROXY SCOPE Option, then it calculates the scope
-   from the source address.  If the scope is larger then specified in
-   the option, then the proxy returns a BADPROXYPOLICY response code.
-   The proxy sets the value of Scope to the actual scope of the source
+   from the source address.  The proxy adds a PROXY SCOPE Option to a
+   reply and sets the value of Scope to the actual scope of the source
    address of the request.
 
    If the request contains a TRUST ANCHOR Option, then the proxy tries
@@ -657,22 +696,15 @@ Internet-Draft                    codcp                        June 2022
    corresponding length to zero.  It is not clear how long the proxy can
    cache this information.  [RFC7958] Does not describe how long these
    documents can be cache.  A simple solution is to take the Expires
-   header in the HTTP reply.
+   header in the HTTP reply.  The proxy adds a TRUST ANCHOR Option to
+   the reply.
 
-11.  Connection Between Stub Resolver And Proxy
+9.  Connection Between Stub Resolver And Proxy
 
    Absent other configuration, a stub resolver that implements this
    standard SHOULD connect to the proxy using Do53 and as remote address
    either ::1 or 127.0.0.1.  In particular, the stub resolver SHOULD
    avoid using name servers listed in files such as /etc/resolv.conf.
-
-
-
-
-Homburg                  Expires 9 December 2022               [Page 12]
-
-Internet-Draft                    codcp                        June 2022
-
 
    The reason for this is to simplify the integration of local DNS
    proxies in existing environments.  If the stub resolver ignores /etc/
@@ -686,9 +718,34 @@ Internet-Draft                    codcp                        June 2022
    case the stub resolver MUST make sure that doing so does not violate
    the policy set by the application.
 
-12.  Security Considerations
 
-13.  IANA Considerations
+
+
+
+
+
+
+Homburg                  Expires 6 January 2023                [Page 13]
+
+Internet-Draft                    codcp                        July 2022
+
+
+10.  Security Considerations
+
+   A privacy sensitive application SHOULD first issue a SOA query for
+   resolver.arpa to verify that the local proxy supports the options
+   documented in the document.  If the proxy does not support this
+   document then the application can refrain from sending queries that
+   reveal privacy sensitive names.
+
+   By setting the interface name, an application can select an outging
+   interface on the proxy.  Proxies should make sure that a query
+   receives from a process that is authorized to do so.  By default, a
+   proxy SHOULD allow only process on the same host to use this feature.
+   If an unauthorized process includes an option with the interface name
+   set, then the proxy SHOULD return the BADPROXYPOLICY error.
+
+11.  IANA Considerations
 
    IANA has assigned the following DNS EDNS0 option codes:
 
@@ -705,12 +762,12 @@ Internet-Draft                    codcp                        June 2022
    -------- ---------------- ----------------------------- -----------
     TBD      BADPROXYPOLICY   Unable to conform to policy   RFC xxxx
 
-14.  Acknowledgements
+12.  Acknowledgements
 
    Many thanks to Yorgos Thessalonikefs and Willem Toorop for their
    feedback.
 
-15.  Normative References
+13.  Normative References
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -721,14 +778,15 @@ Internet-Draft                    codcp                        June 2022
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
-16.  Informative References
 
 
 
-Homburg                  Expires 9 December 2022               [Page 13]
+Homburg                  Expires 6 January 2023                [Page 14]
 
-Internet-Draft                    codcp                        June 2022
+Internet-Draft                    codcp                        July 2022
 
+
+14.  Informative References
 
    [RFC1035]  Mockapetris, P., "Domain names - implementation and
               specification", STD 13, RFC 1035, DOI 10.17487/RFC1035,
@@ -742,6 +800,12 @@ Internet-Draft                    codcp                        June 2022
    [RFC5011]  StJohns, M., "Automated Updates of DNS Security (DNSSEC)
               Trust Anchors", STD 74, RFC 5011, DOI 10.17487/RFC5011,
               September 2007, <https://www.rfc-editor.org/info/rfc5011>.
+
+   [RFC5280]  Cooper, D., Santesson, S., Farrell, S., Boeyen, S.,
+              Housley, R., and W. Polk, "Internet X.509 Public Key
+              Infrastructure Certificate and Certificate Revocation List
+              (CRL) Profile", RFC 5280, DOI 10.17487/RFC5280, May 2008,
+              <https://www.rfc-editor.org/info/rfc5280>.
 
    [RFC5625]  Bellis, R., "DNS Proxy Implementation Guidelines",
               BCP 152, RFC 5625, DOI 10.17487/RFC5625, August 2009,
@@ -771,20 +835,16 @@ Internet-Draft                    codcp                        June 2022
               RFC 7958, DOI 10.17487/RFC7958, August 2016,
               <https://www.rfc-editor.org/info/rfc7958>.
 
+
+
+Homburg                  Expires 6 January 2023                [Page 15]
+
+Internet-Draft                    codcp                        July 2022
+
+
    [RFC8484]  Hoffman, P. and P. McManus, "DNS Queries over HTTPS
               (DoH)", RFC 8484, DOI 10.17487/RFC8484, October 2018,
               <https://www.rfc-editor.org/info/rfc8484>.
-
-
-
-
-
-
-
-Homburg                  Expires 9 December 2022               [Page 14]
-
-Internet-Draft                    codcp                        June 2022
-
 
    [RFC9000]  Iyengar, J., Ed. and M. Thomson, Ed., "QUIC: A UDP-Based
               Multiplexed and Secure Transport", RFC 9000,
@@ -833,8 +893,4 @@ Author's Address
 
 
 
-
-
-
-
-Homburg                  Expires 9 December 2022               [Page 15]
+Homburg                  Expires 6 January 2023                [Page 16]

--- a/notes/dns-client-proxy.txt
+++ b/notes/dns-client-proxy.txt
@@ -3,9 +3,9 @@
 
 
 ADD                                                         P.C. Homburg
-Internet-Draft                                                6 May 2022
+Internet-Draft                                               3 June 2022
 Intended status: Standards Track                                        
-Expires: 7 November 2022
+Expires: 5 December 2022
 
 
                  Control Options For DNS Client Proxies
@@ -13,7 +13,7 @@ Expires: 7 November 2022
 
 Abstract
 
-   The introduction of many new transport portocols for DNS in recent
+   The introduction of many new transport protocols for DNS in recent
    years (DoT, DoH, DoQ) significantly increases the complexity of DNS
    stub resolvers that want to support these protocols.  A practical way
    forward is to have a DNS client proxy in the host operating system.
@@ -40,7 +40,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 7 November 2022.
+   This Internet-Draft will expire on 5 December 2022.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Homburg                  Expires 7 November 2022                [Page 1]
+Homburg                  Expires 5 December 2022                [Page 1]
 
-Internet-Draft                    codcp                         May 2022
+Internet-Draft                    codcp                        June 2022
 
 
    Please review these documents carefully, as they describe your rights
@@ -81,8 +81,9 @@ Table of Contents
    11. Connection Between Stub Resolver And Proxy  . . . . . . . . .  11
    12. Security Considerations . . . . . . . . . . . . . . . . . . .  12
    13. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  12
-   14. Normative References  . . . . . . . . . . . . . . . . . . . .  12
-   15. Informative References  . . . . . . . . . . . . . . . . . . .  12
+   14. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  12
+   15. Normative References  . . . . . . . . . . . . . . . . . . . .  12
+   16. Informative References  . . . . . . . . . . . . . . . . . . .  12
    Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  13
 
 1.  Definitions
@@ -105,14 +106,15 @@ Table of Contents
    h2  This TLS ALPN identifies HTTP/2 as described in [RFC7540]
 
    h3  This TLS ALPN identifies HTTP/3, which is HTTP over QUIC and is
-      described in I.D.ietf-quic-http (expired draft)
 
 
 
-Homburg                  Expires 7 November 2022                [Page 2]
+Homburg                  Expires 5 December 2022                [Page 2]
 
-Internet-Draft                    codcp                         May 2022
+Internet-Draft                    codcp                        June 2022
 
+
+      described in I.D.ietf-quic-http (expired draft)
 
    Interface Name  A name that identifies a network interface as
       described in [RFC3493].  In addition, an interface index converted
@@ -120,7 +122,7 @@ Internet-Draft                    codcp                         May 2022
 
 2.  Introduction
 
-   The introduction of many new transport portocols for DNS in recent
+   The introduction of many new transport protocols for DNS in recent
    years (DoT, DoH, DoQ) significantly increases the complexity of DNS
    stub resolvers that want to support these protocols.  In addition,
    for short-lived applications, the overhead of setting a DoH
@@ -145,7 +147,7 @@ Internet-Draft                    codcp                         May 2022
    With respect to DNSSEC, we assume that an application that needs
    DNSSEC validation, for example, for DANE validation or SSHFP, will
    perform the DNSSEC validation within the application itself and does
-   not trust the proxy.  The proxy can ofcourse do DNSSEC validation as
+   not trust the proxy.  The proxy can of course do DNSSEC validation as
    well.  Important however, is that an untrusted proxy cannot provide
    an application with a traditional (unsigned) trust anchor.
 
@@ -163,11 +165,9 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-
-
-Homburg                  Expires 7 November 2022                [Page 3]
+Homburg                  Expires 5 December 2022                [Page 3]
 
-Internet-Draft                    codcp                         May 2022
+Internet-Draft                    codcp                        June 2022
 
 
    A poorly constructed DNS client proxy may forward DNS packets without
@@ -175,10 +175,10 @@ Internet-Draft                    codcp                         May 2022
    introduce an option that limits the connection to host-local, link-
    local, or site-local.  The requirement on a conforming DNS client
    proxy is to check where a request comes from and compare this to the
-   option in the request (if any).  And error is returned if there is a
+   option in the request (if any).  An error is returned if there is a
    mismatch.
 
-   In a reponse, the proxy reports the interface, resolver, and
+   In a response, the proxy reports the interface, resolver, and
    transport used.
 
    In the ideal case, the host operating system provides applications
@@ -200,10 +200,10 @@ Internet-Draft                    codcp                         May 2022
 
 4.  Description
 
-   This document introduces the new EDNS(0) options, and one new status
-   code.  This first option, called PROXY CONTROL Option, specifies
-   which transports a proxy should use to connect to a recursive
-   resolver.
+   This document introduces the new EDNS(0) options, and one new
+   response code.  This first option, called PROXY CONTROL Option,
+   specifies which transports a proxy should use to connect to a
+   recursive resolver.
 
    The second option, called PROXY SCOPE Option, controls the IP address
    scope of the connection between the application's stub resolver and
@@ -221,9 +221,9 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 7 November 2022                [Page 4]
+Homburg                  Expires 5 December 2022                [Page 4]
 
-Internet-Draft                    codcp                         May 2022
+Internet-Draft                    codcp                        June 2022
 
 
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
@@ -277,9 +277,9 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 7 November 2022                [Page 5]
+Homburg                  Expires 5 December 2022                [Page 5]
 
-Internet-Draft                    codcp                         May 2022
+Internet-Draft                    codcp                        June 2022
 
 
       authenticate using DANE
@@ -333,16 +333,16 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 7 November 2022                [Page 6]
+Homburg                  Expires 5 December 2022                [Page 6]
 
-Internet-Draft                    codcp                         May 2022
+Internet-Draft                    codcp                        June 2022
 
 
    authenticated encryptions.  With the U, UA, and A flags clear, an
    effort is made to reach authenticated encryption, if that fails
    unauthenticated encryption and if that fails, fall back to an
-   unencryption transport.  The P and D flags allow the application to
-   require a specfic authentication mechanism (PKI or DANE).  When both
+   unencrypted transport.  The P and D flags allow the application to
+   require a specific authentication mechanism (PKI or DANE).  When both
    flags are set, PKI and DANE are required together.  If no flags are
    set, are least one of the two has to succeed if authenticated
    encryption is required.
@@ -354,27 +354,27 @@ Internet-Draft                    codcp                         May 2022
    the transport.  There is space to add more transports later.
 
    To future proof applications, there is a single flag DO, that
-   disallows transports that are not explicitly listed.  Which this flag
+   disallows transports that are not explicitly listed.  With this flag
    clear, the application allows future transports.  With the flag set,
    the application has to explicitly list which transports can be used.
    For example, by setting only DO and AT, the application forces the
    use of DoT.
 
-   Finally, an application can specify it's own resolvers or rely on the
+   Finally, an application can specify its own resolvers or rely on the
    resolvers that are know to the proxy.  If ADN Length and Addr Length
    are both zero, then the application requests to resolvers known to
    the proxy.  [Note: it is unclear at the moment what to do with any
    Service Parameters]
 
    If the application specifies only an authentication-domain-name then
-   the proxy is expect to resolve the name to addresses.  If only
+   the proxy is expected to resolve the name to addresses.  If only
    addresses are specified then the proxy assumes that no name is known
    (though a PKI certificate may include an address literal in the
    subjectAltName).  If both a name and address are specified then the
    proxy will use the specified addresses and use the name for
    authentication.
 
-   To simplify the encoding of the option, an option with addresses with
+   To simplify the encoding of the option, an option with addresses will
    have either IPv4 or IPv6 addresses.  If the application wants to
    specify both IPv4 and IPv6 address for a certain authentication-
    domain-name then it has to include two options.
@@ -389,9 +389,9 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 7 November 2022                [Page 7]
+Homburg                  Expires 5 December 2022                [Page 7]
 
-Internet-Draft                    codcp                         May 2022
+Internet-Draft                    codcp                        June 2022
 
 
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
@@ -406,7 +406,7 @@ Internet-Draft                    codcp                         May 2022
       To be decided
 
    OPTION-LENGTH
-      Lenght of this option excluding the OPTION-CODE and OPTION-LENGTH
+      Length of this option excluding the OPTION-CODE and OPTION-LENGTH
       fields
 
    Scope
@@ -429,12 +429,12 @@ Internet-Draft                    codcp                         May 2022
 
                                    Table 1
 
-   The purpose of this option is deal with badly implemented proxy that
-   forward DNS traffic without first removing any EDNS(0) options.  The
-   option request the DNS proxy that processes the option to report the
-   scope of the source address.  The application can specify that the
-   connection between the stub resolver and the proxy should have, for
-   example, at most host local scope.
+   The purpose of this option is to deal with badly implemented proxies
+   that forward DNS traffic without first removing any EDNS(0) options.
+   The option requests the DNS proxy that processes the option to report
+   the scope of the source address.  The application can specify that
+   the connection between the stub resolver and the proxy should have,
+   for example, at most host local scope.
 
 7.  TRUST ANCHOR OPTION
 
@@ -445,9 +445,9 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 7 November 2022                [Page 8]
+Homburg                  Expires 5 December 2022                [Page 8]
 
-Internet-Draft                    codcp                         May 2022
+Internet-Draft                    codcp                        June 2022
 
 
        +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
@@ -501,14 +501,14 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 7 November 2022                [Page 9]
+Homburg                  Expires 5 December 2022                [Page 9]
 
-Internet-Draft                    codcp                         May 2022
+Internet-Draft                    codcp                        June 2022
 
 
    If the stub resolver receives a reply without a PROXY CONTROL Option
    included in the reply, then stub resolver has to assume that traffic
-   will have Do%3 levels of privacy.  Similarly, a lack of a PROXY SCOPE
+   will have Do53 levels of privacy.  Similarly, a lack of a PROXY SCOPE
    Option implies a global scope.
 
    If the stub resolver receives a BADPROXYPOLICY error then the proxy
@@ -517,18 +517,18 @@ Internet-Draft                    codcp                         May 2022
 
 9.1.  Probing
 
-   In cases where the stub resolvers expects a local DNS proxy, or where
+   In cases where the stub resolver expects a local DNS proxy, or where
    the stub resolver has (a limited) fall back to more private
    transports, or when the security policy of the application is such
-   that is better to fail then the send queries over Do53, the stub
-   resolver first sends probing query to verify that the proxy supports
-   the PROXY CONTROL and PROXY SCOPE options.
+   that is better to fail than send queries over Do53, the stub resolver
+   first sends a probing query to verify that the proxy supports the
+   PROXY CONTROL and PROXY SCOPE options.
 
    This request queries "resolver.arpa".  The proxy MUST implement this
    as a Special Use Domain Name.  The actual response is not important.
    The important part is that the proxy returns PROXY CONTROL and PROXY
-   SCOPE options as described in the this documents and optionally sets
-   the result to BADPROXYPOLICY specified policy.
+   SCOPE options as described in this document and optionally sets the
+   response code to BADPROXYPOLICY specified policy.
 
 9.2.  Trust Anchor
 
@@ -557,9 +557,9 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 7 November 2022               [Page 10]
+Homburg                  Expires 5 December 2022               [Page 10]
 
-Internet-Draft                    codcp                         May 2022
+Internet-Draft                    codcp                        June 2022
 
 
 10.  Server Processing
@@ -567,37 +567,37 @@ Internet-Draft                    codcp                         May 2022
    Proxies are encouraged to cache options that appear in requests under
    the assumption that a stub resolver will send multiple requests.  If
    a proxy caches DNS responses then the proxy MUST tag cached responses
-   with the properties of the DNS transport.  When responding the later
-   requests, then proxy returns a cached entry only if the parameters of
+   with the properties of the DNS transport.  When responding to later
+   requests, the proxy returns a cached entry only if the parameters of
    the DNS transport match what is specified in the request.
 
    When a proxy receives a new set of requirements, the proxy compiles a
-   list of addresses to connect to and per address a list of transports
-   to try.  The proxy SHOULD prefer more private transports over less
+   list of addresses to connect to and a list of transports to try per
+   address.  The proxy SHOULD prefer more private transports over less
    private ones.
 
-   If the proxy cannot obtain a connect to a recursive resolver in a way
-   that matches the provided policy, then the proxy sets the
-   BADPROXYPOLICY status in the reply.  In addition the proxy SHOULD try
-   to find at least one connection to a recursive resolver.  If the
-   proxy did not find an alternative connection to recursive resolver
-   (also if it didn't try) then the proxy include a PROXY POLICY Option
-   with all flags set to zero, and with ADN Length, Addr Length, and
-   SvcParams Length set to zero as well.
+   If the proxy cannot obtain a connection to a recursive resolver in a
+   way that matches the provided policy, then the proxy sets the
+   BADPROXYPOLICY response code in the reply.  In addition the proxy
+   SHOULD try to find at least one connection to a recursive resolver.
+   If the proxy did not find an alternative connection to a recursive
+   resolver (also if it didn't try) then the proxy includes a PROXY
+   CONTROL Option with all flags set to zero, and with ADN Length, Addr
+   Length, and SvcParams Length set to zero as well.
 
    If the proxy does have one or more alternative connections to
-   resursive resolvers then the proxy generates options with the
+   recursive resolvers then the proxy generates options with the
    properties of those connection, with a maximum of three connections.
 
    If the proxy finds a PROXY SCOPE Option, then it calculates the scope
    from the source address.  If the scope is larger then specified in
-   the option, then the proxy returns a BADPROXYPOLICY status.  The
-   proxy sets the value of Scope to the actual scope of the source
+   the option, then the proxy returns a BADPROXYPOLICY response code.
+   The proxy sets the value of Scope to the actual scope of the source
    address of the request.
 
    If the request contains a TRUST ANCHOR Option, then the proxy tries
    to fetch the trust anchor XML and p7s files if it does not have them
-   already.  If fetch one or both fails then the proxy sets the
+   already.  If fetching one or both fails then the proxy sets the
    corresponding length to zero.  It is not clear how long the proxy can
    cache this information.  [RFC7958] Does not describe how long these
    documents can be cache.  A simple solution is to take the Expires
@@ -613,12 +613,12 @@ Internet-Draft                    codcp                         May 2022
 
 
 
-Homburg                  Expires 7 November 2022               [Page 11]
+Homburg                  Expires 5 December 2022               [Page 11]
 
-Internet-Draft                    codcp                         May 2022
+Internet-Draft                    codcp                        June 2022
 
 
-   There reason for this is to simply the intergration of local DNS
+   There reason for this is to simplify the integration of local DNS
    proxies in existing environments.  If the stub resolver ignores /etc/
    resolv.conf then the proxy can use that information to connect to
    recursive resolvers.
@@ -638,18 +638,23 @@ Internet-Draft                    codcp                         May 2022
 
     Value   Name           Status     Reference
    ------- -------------- ---------- -----------
-    TBD     PROXY POLICY   Standard   RFC xxxx
+    TBD     PROXY CONTROL  Standard   RFC xxxx
     TBD     PROXY SCOPE    Standard   RFC xxxx
     TBD     TRUST ANCHOR   Standard   RFC xxxx
 
-   IANA has assigned the following DNS error code as an early allocation
-   per [RFC7120]:
+   IANA has assigned the following DNS response code as an early
+   allocation per [RFC7120]:
 
     RCODE    Name             Description                   Reference
    -------- ---------------- ----------------------------- -----------
     TBD      BADPROXYPOLICY   Unable to conform to policy   RFC xxxx
 
-14.  Normative References
+14.  Acknowledgements
+
+   Many thanks to Yorgos Thessalonikefs and Willem Toorop for their
+   feedback.
+
+15.  Normative References
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
               Requirement Levels", BCP 14, RFC 2119,
@@ -660,19 +665,18 @@ Internet-Draft                    codcp                         May 2022
               2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
               May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 
-15.  Informative References
+16.  Informative References
+
+
+
+Homburg                  Expires 5 December 2022               [Page 12]
+
+Internet-Draft                    codcp                        June 2022
+
 
    [RFC1035]  Mockapetris, P., "Domain names - implementation and
               specification", STD 13, RFC 1035, DOI 10.17487/RFC1035,
               November 1987, <https://www.rfc-editor.org/info/rfc1035>.
-
-
-
-
-Homburg                  Expires 7 November 2022               [Page 12]
-
-Internet-Draft                    codcp                         May 2022
-
 
    [RFC3493]  Gilligan, R., Thomson, S., Bound, J., McCann, J., and W.
               Stevens, "Basic Socket Interface Extensions for IPv6",
@@ -718,6 +722,14 @@ Internet-Draft                    codcp                         May 2022
 
 Author's Address
 
+
+
+
+Homburg                  Expires 5 December 2022               [Page 13]
+
+Internet-Draft                    codcp                        June 2022
+
+
    Philip Homburg
 
    Email: philip@nlnetlabs.nl
@@ -725,4 +737,48 @@ Author's Address
 
 
 
-Homburg                  Expires 7 November 2022               [Page 13]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Homburg                  Expires 5 December 2022               [Page 14]

--- a/notes/dns-client-proxy.xml
+++ b/notes/dns-client-proxy.xml
@@ -1,0 +1,645 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- name="GENERATOR" content="github.com/mmarkdown/mmark Mmark Markdown Processor - mmark.miek.nl" -->
+<rfc version="3" ipr="trust200902" docName="draft-homburg-add-codcp-00" submissionType="IETF" category="std" xml:lang="en" xmlns:xi="http://www.w3.org/2001/XInclude" indexInclude="true" consensus="true">
+
+<front>
+<title abbrev="codcp">Control Options For DNS Client Proxies</title><seriesInfo value="draft-homburg-add-codcp-00" stream="IETF" status="standard" name="Internet-Draft"></seriesInfo>
+<author initials="P.C." surname="Homburg" fullname="Philip Homburg"><organization></organization><address><postal><street></street>
+</postal><email>philip@nlnetlabs.nl</email>
+</address></author><date/>
+<area>Internet</area>
+<workgroup>ADD</workgroup>
+
+<abstract>
+<t>The introduction of many new transport protocols for DNS in recent years
+(DoT, DoH, DoQ)
+significantly increases the complexity of DNS stub
+resolvers that want to support these protocols. A practical way forward
+is to have a DNS client proxy in the host operating system. This allows
+applications to communicate using Do53 and still get the privacy
+benefit from using more secure protocols over the internet. However,
+such a setup leaves the application with no control over which transport
+the proxy uses. This document introduces EDNS(0) options that allow a
+stub resolver to request certain transport and allow the proxy to report
+capabilities and actual transports that are available.</t>
+</abstract>
+
+</front>
+
+<middle>
+
+<section anchor="definitions"><name>Definitions</name>
+
+<dl>
+<dt>Do53</dt>
+<dd><t>The original, plain text DNS transport as described in <xref target="RFC1034"></xref><xref target="RFC1035"></xref>.
+Typically, UDP is used, with the DNS server listening on port 53. Sometimes,
+for example, for large responses, TCP is used, also on port 53.</t>
+</dd>
+<dt>DoH</dt>
+<dd><t>DNS over HTTPS as described in <xref target="RFC8484"></xref>.</t>
+</dd>
+<dt>DoT</dt>
+<dd><t>DNS over TLS as described in <xref target="RFC7858"></xref></t>
+</dd>
+<dt>DoQ</dt>
+<dd><t>DNS over QUIC (<xref target="RFC9000"></xref>) as described in [I-D.ietf-dprive-dnsoquic],
+not to be confused with DNS over HTTP/3 which also uses QUIC</t>
+</dd>
+<dt>EDNS(0) Option</dt>
+<dd><t>An option as described in <xref target="RFC6891"></xref></t>
+</dd>
+<dt>h2</dt>
+<dd><t>This TLS ALPN identifies HTTP/2 as described in <xref target="RFC7540"></xref></t>
+</dd>
+<dt>h3</dt>
+<dd><t>This TLS ALPN identifies HTTP/3, which is HTTP over QUIC and
+is described in I.D.ietf-quic-http (expired draft)</t>
+</dd>
+<dt>Interface Name</dt>
+<dd><t>A name that identifies a network interface as described in <xref target="RFC3493"></xref>.
+In addition, an interface index converted to a decimal number is also
+consider an interface name.</t>
+</dd>
+<dt>PKIX</dt>
+<dd><t>Public-Key Infrastructure using X.509. See <xref target="RFC5280"></xref></t>
+</dd>
+</dl>
+</section>
+
+<section anchor="introduction"><name>Introduction</name>
+<t>The introduction of many new transport protocols for DNS in recent years
+(DoT, DoH, DoQ)
+significantly increases the complexity of DNS stub
+resolvers that want to support these protocols. In addition,
+for short-lived applications, the overhead of setting a DoH connection
+is quite high if the application only needs to send a few DNS requests.</t>
+<t>A practical way forward
+is to have a DNS client proxy in the host operating system.
+A local proxy may provide some benefit to short-lived applications by
+caching results. In particular if the system uses a so called 'public
+DNS resolver'. In general we assume that the cache is tagged according
+to the source of a reply and the transport it is received on.</t>
+<t>This allows
+applications to communicate using Do53 and still get the privacy
+benefits from using more secure protocols over the internet. However,
+such a setup leaves the application with no control over which transport
+the proxy uses. This document introduces EDNS(0) options that allow a
+stub resolver to request certain transports and allow the proxy to report
+capabilities and actual transports that are available.</t>
+<t>With respect to DNSSEC, we assume that an application that needs
+DNSSEC validation, for example, for DANE validation or SSHFP, will
+perform the DNSSEC validation within the application itself and does not
+trust the proxy. The proxy can of course do DNSSEC validation as well.
+Important however, is that an untrusted proxy cannot provide an application
+with a traditional (unsigned) trust anchor.</t>
+<t>For the transport configuration we expect three levels of details. The
+first is a choice between requiring authenticated encryption, also allowing unauthenticated encryption or doing opportunistic encryption on an best effort basis. The second level is where the application also
+specifies the names and/or IP addresses of upstream resolvers. The
+third level is where the application also specifies which transports
+(Do53, DoT, DoH, DoQ) are allowed to be used. A final transport parameter
+is the outgoing interface that is to be used.</t>
+<t>For authentication we can have a mix of PKIX and DANE. Options are one of
+the two and not the other, both or one of the two.</t>
+<t>In a response, the proxy reports the interface, resolver, and transport
+used.</t>
+<t>As described in <xref target="RFC5625" sectionFormat="bare" relative="#" section="Section 3"></xref> of <xref target="RFC5625"></xref>, some simple DNS proxies
+may just forward DNS packets without handling of EDNS(0) options.
+So what could happen is that an application sends a privacy sensitive
+request to local proxy,
+expecting the proxy upstream connection to be encrypted. However, a simple
+proxy may just forward the request unencrypted to another proxy, for example,
+one in a CPE that does implement the protocol described in this document. So
+what could happen is that the request travels unencrypted over a local lan,
+or if proxies deeper in the network support this protocol, even further
+without the application noticing that something is wrong.</t>
+<t>To handle this case, we introduce an option where the proxy reports
+whether the connection between the stub resolver and the proxy is
+host-local, link-local, or site-local or global.</t>
+<t>In the ideal case, the host operating system provides applications with a
+secure way to access a DNSSEC trust anchor that is maintained according to
+<xref target="RFC5011"></xref>. However in situations where this is not the case, an application
+can fall back to <xref target="RFC7958"></xref>. However, for short lived processes, there is
+considerable overhead in issuing two HTTP(S) requests to data.iana.org to
+obtain the trust anchor XML file and the signature over the trust anchor.
+For this reason, it makes sense to let the proxy cache this information.</t>
+</section>
+
+<section anchor="key-words"><name>Key Words</name>
+<t>The key words &quot;<bcp14>MUST</bcp14>&quot;, &quot;<bcp14>MUST NOT</bcp14>&quot;, &quot;<bcp14>REQUIRED</bcp14>&quot;, &quot;<bcp14>SHALL</bcp14>&quot;, &quot;<bcp14>SHALL NOT</bcp14>&quot;,
+&quot;<bcp14>SHOULD</bcp14>&quot;, &quot;<bcp14>SHOULD NOT</bcp14>&quot;, &quot;<bcp14>RECOMMENDED</bcp14>&quot;, &quot;<bcp14>NOT RECOMMENDED</bcp14>&quot;, &quot;<bcp14>MAY</bcp14>&quot;, and
+&quot;<bcp14>OPTIONAL</bcp14>&quot; in this document are to be interpreted as described in BCP 14 <xref target="RFC2119"></xref> <xref target="RFC8174"></xref>
+when, and only when, they appear in all capitals, as shown here.</t>
+</section>
+
+<section anchor="description"><name>Description</name>
+<t>This document introduces three new EDNS(0) options, and one new response code.
+This first option, called PROXY CONTROL Option, specifies which transports
+a proxy should use to connect to a recursive resolver.</t>
+<t>The second option, called PROXY SCOPE Option, reports the IP address scope
+of the connection between the application's stub resolver and the proxy.</t>
+<t>Finally, the TRUST ANCHOR Option, provides the application with a DNSSEC
+trust anchor signed by IANA.</t>
+<t>The BADPROXYPOLICY error is returned the proxy cannot meet the requirements
+in a PROXY CONTROL Option or the option is malformed.</t>
+</section>
+
+<section anchor="proxy-control-option"><name>PROXY CONTROL OPTION</name>
+
+<artwork>      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   0: |                          OPTION-CODE                          |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   2: |                         OPTION-LENGTH                         |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   4: | U |UA | A | P | D |DD |                     Z                 |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   6: |A53|D53|AT |DT |AH2|DH2|AH3|DH3|AQ |DQ |         Z             |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   8: |         Addr Type             |         Addr Length           |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-|
+      ~                IPv4 or IPv6-address(es)                       ~
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+      |  Domain Name Length           |                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
+      ~                   Domain Name                                 ~
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |          SvcParams Length     |                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
+      ~                 SvcParams                                     ~
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+      |     Interface Name Length     |                               |
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
+      ~                 Interface Name                                ~
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</artwork>
+<t>where</t>
+
+<dl newline="true">
+<dt>OPTION-CODE</dt>
+<dd><t>To be decided</t>
+</dd>
+<dt>OPTION-LENGTH</dt>
+<dd><t>Length of this option excluding the OPTION-CODE and OPTION-LENGTH fields</t>
+</dd>
+<dt>U</dt>
+<dd><t>force the use of unencrypted communication (Do53)</t>
+</dd>
+<dt>UA</dt>
+<dd><t>require unauthenticated encryption</t>
+</dd>
+<dt>A</dt>
+<dd><t>require authenticated encryption</t>
+</dd>
+<dt>P</dt>
+<dd><t>authenticate using a PKIX certificate</t>
+</dd>
+<dt>D</dt>
+<dd><t>authenticate using DANE</t>
+</dd>
+<dt>DD</dt>
+<dd><t>by default disallow other transports
+(transports that are not explicitly listed)</t>
+</dd>
+<dt>A53,AT,AH2,AH3,AQ</dt>
+<dd><t>allow respectively Do53, DoT, DoH H2, DoH H3, DoQ</t>
+</dd>
+<dt>D53,DT,DH2,DH3,DQ</dt>
+<dd><t>disallow respectively Do53, DoT, DoH H2, DoH H3, DoQ</t>
+</dd>
+<dt>Z</dt>
+<dd><t>reserved, MUST be zero when sending, MUST be ignored when received</t>
+</dd>
+<dt>Addr Type</dt>
+<dd><t>Type of addresses, The value 0 if no addresses are included, the value 1 for
+IPv4, and the value 2 for IPv6.</t>
+</dd>
+<dt>Addr Length</dt>
+<dd><t>length of the addresses in octets. Must be a multiple of 4 for IPv4 and
+a multiple of 16 for IPv6. This field can be zero if no addresses are
+specified.</t>
+</dd>
+<dt>IPv4 or IPv6-address(es)</dt>
+<dd><t>list of IPv4 or IPv6 addresses</t>
+</dd>
+<dt>Domain Name Length</dt>
+<dd><t>length of Domain Name. Zero if there is no Domain Name</t>
+</dd>
+<dt>Domain Name</dt>
+<dd><t>domain name for authentication or resolving IP addresses. The domain name
+is encoded in uncompressed DNS wire format.</t>
+</dd>
+<dt>SvcParams Length</dt>
+<dd><t>length of SvcParams. Zero if there are no service parameters specified.</t>
+</dd>
+<dt>SvcParams</dt>
+<dd><t>Service parameters</t>
+</dd>
+<dt>Interface Name Length</dt>
+<dd><t>length of Interface Name. Zero if no interface is specified.</t>
+</dd>
+<dt>Interface Name</dt>
+<dd><t>name of outgoing interface for transport connections</t>
+</dd>
+</dl>
+<t>This option is designed to give control over what level of detail it
+wants to specify. The first 5 flags (U, UA, A, P, and D) give general
+requirements for properties of DNS transports that are used by the
+client proxy.
+The U, UA, and A flags are mutually exclusive. If more than one
+flag is set, the proxy SHOULD return a BADPROXYPOLICY error.
+There are four possibilities:</t>
+
+<dl>
+<dt>U = 0, UA = 0, A = 0</dt>
+<dd><t>An effort is made to reach authenticated encryption, if that fails,
+unauthenticated encryption is tried. If that also fails, the proxy
+resorts to an unencrypted transport.
+It is an error
+if either or both of the P or D flags is set and the proxy SHOULD
+return a BADPROXYPOLICY error.</t>
+</dd>
+<dt>U = 1, UA = 0, A = 0</dt>
+<dd><t>The proxy only tries only unencrypted transports.
+It is an error
+if either or both of the P or D flags is set and the proxy SHOULD return a
+BADPROXYPOLICY error.</t>
+</dd>
+<dt>U = 0, UA = 1, A = 0</dt>
+<dd><t>An effort is made to reach authenticated encryption, if that fails,
+unauthenticated encryption is tried.
+It is an error
+if either or both of the P or D flags is set and the proxy SHOULD return a
+BADPROXYPOLICY error.</t>
+</dd>
+<dt>U = 0, UA = 0, A = 1</dt>
+<dd><t>The proxy only tries authenticated encryption. The P and D flags can be
+set to control which authentication mechanism has to be used.</t>
+</dd>
+</dl>
+<t>The P and D flags allow the application to require
+a specific authentication mechanism (PKIX or DANE). The meaning of the
+flags is the following:</t>
+
+<dl>
+<dt>P = 0, D = 0</dt>
+<dd><t>At least one of the two mechanisms has to validate for authenticated
+encryption to succeed.</t>
+</dd>
+<dt>P = 1, D = 0</dt>
+<dd><t>PKIX validation has to succeed, the status of DANE validation is ignored.</t>
+</dd>
+<dt>P = 0, D = 1</dt>
+<dd><t>A DANE record has to be present and be DNSSEC valid.
+A DANE record has
+a Certificate Usage Field. For some values of this field (the values zero
+and one), DANE requires PKIX validation.
+In those cases, PKIX validation is also required according to the DANE
+specifications. For the values two and three, DANE does not require
+PKIX and because the P flag is zero, the result of PKIX validation has to
+be ignored.</t>
+</dd>
+<dt>P = 1, D = 1</dt>
+<dd><t>Both PKIX and DANE are required together. For PKIX, this means that
+PKIX validation has to succeed. For DANE it means that a DANE record
+has to be present and be DNSSEC valid. Validation using the DANE record
+has to succeed.</t>
+</dd>
+</dl>
+<t>Note that these two flags can only be used in combination with the A
+flag. The proxy SHOULD return a BADPROXYPOLICY error if either or both of the
+P or D flags is set and the A flag is clear.</t>
+<t>The next flags provide more detailed control over which transports
+should be used or not. For each of 5 different transports
+(Do53, DoT, DoH with ALPN h2, DoH with ALPN h3, DoQ) there is a flag
+to allow (A53,AT,AH2,AH3,AQ) or disallow (D53,DT,DH2,DH3,DQ) the use of the
+transport. There is space to add more transports later. Note that setting
+the A flag and the D flag for a protocol (for example, setting both the
+A53 and the D53 flags) is not allowed and a proxy SHOULD reject such a request.</t>
+<t>To future proof applications, there is a single flag DD, that by default
+disallows transports that are not explicitly listed. With this flag clear,
+the application allows all transports that are not explicitly disallowed
+(including future transports). With the flag set, the
+application has to explicitly list which transports can be used.
+For example, by setting only DD and AT, the application forces the
+use of DoT.</t>
+<t>When DD = 0:</t>
+
+<ul spacing="compact">
+<li>all transports are in the pool of potentially usable transports</li>
+<li>D53, DT, DH2, DH3 and DQ remove those transports from the pool.</li>
+<li>The values of A53, AT, AH2, AH3 and AQ are irrelevant</li>
+</ul>
+<t>When DD = 1:</t>
+
+<ul spacing="compact">
+<li>no transports are in the pool of potentially usable transports</li>
+<li>A53, AT, AH2, AH3 and AQ add those transports to the pool</li>
+<li>The values of D53, DT, DH2, DH3 and DQ are irrelevant</li>
+</ul>
+<t>Finally, an application can specify its own resolvers or rely on the
+resolvers that are known to the proxy. If ADN Length and Addr Length
+are both zero, then the application requests the resolvers known to
+the proxy. [Note: it is unclear at the moment what to do with any
+Service Parameters]</t>
+<t>If the application specifies only an authentication-domain-name then the
+proxy is expected to resolve the name to addresses. If only addresses
+are specified then the proxy assumes that no name is known (though
+a PKIX certificate may include an address literal in the subjectAltName).
+If both a name and address are specified then the proxy will use the
+specified address and use the name for authentication.</t>
+<t>To simplify the encoding of the option, an option with addresses will
+have either IPv4 or IPv6 addresses. If the application wants to specify
+both IPv4 and IPv6 addresses for a certain authentication-domain-name
+then it has to include two options.</t>
+<t>An application may want to specify a DNS resolver that is reachable
+through an IPv6 link-local address.
+IPv6 link-local addresses are special in that they require a zone to be
+specified, either explicitly or implicitly. Typically for a link-local
+address that appears as a source or destination address,
+the zone is implicitly the zone of the link the packet travels on.
+For packets that travel between hosts, there is no goed way to explictly
+specify the zone of a link-local address because two different hosts
+do not agree on zone names. However, if the proxy is on the same host
+as the application, then the zone identifier for the link-local address
+can be specified in the Interface field. For this purpose an interface
+name can also be an interface index expressed as a decimal string.</t>
+<t>When present, Service Parameters specify how to connect. Otherwise it is
+up to the proxy to try various possibilities. For Service Parameters,
+the values of the ipv4hint and ipv6hint fields are ignored. Addresses
+can only be specified using the addresses field in the PROXY CONTROL Option.</t>
+<t>Associated with this option is a new error, BADPROXYPOLICY. When
+a proxy cannot meet the requirements in a PROXY CONTROL Option or the
+option is malformed, it returns this error.</t>
+<t>If the proxy returns a BADPROXYPOLICY error, the proxy MAY include
+a PROXY CONTROL Option that lists what the proxy can do. For example,
+if authenticated encryption is not possible, but unauthenticated is,
+then the proxy may include an option that has the UA bit set.</t>
+</section>
+
+<section anchor="proxy-scope-option"><name>PROXY SCOPE OPTION</name>
+
+<artwork>      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   0: |                          OPTION-CODE                          |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   2: |                         OPTION-LENGTH                         |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   4: |                          Scope                                |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+</artwork>
+
+<dl newline="true">
+<dt>OPTION-CODE</dt>
+<dd><t>To be decided</t>
+</dd>
+<dt>OPTION-LENGTH</dt>
+<dd><t>Length of this option excluding the OPTION-CODE and OPTION-LENGTH fields</t>
+</dd>
+<dt>Scope</dt>
+<dd><t>Scope of the source address of a request. Scope can have the following
+values:</t>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Scope</th>
+</tr>
+</thead>
+
+<tbody>
+<tr>
+<td>0</td>
+<td>Undefined</td>
+</tr>
+
+<tr>
+<td>1</td>
+<td>Host local</td>
+</tr>
+
+<tr>
+<td>2</td>
+<td>Link local</td>
+</tr>
+
+<tr>
+<td>3</td>
+<td>Site local</td>
+</tr>
+
+<tr>
+<td>4</td>
+<td>Global</td>
+</tr>
+</tbody>
+</table></dd>
+</dl>
+<t>The purpose of this option is to deal with proxies that forward
+DNS traffic without first removing any EDNS(0) options. The option requests
+the DNS proxy that processes the option to report the scope of the source
+address.</t>
+</section>
+
+<section anchor="trust-anchor-option"><name>TRUST ANCHOR OPTION</name>
+
+<artwork>      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   0: |                          OPTION-CODE                          |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   2: |                         OPTION-LENGTH                         |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   4: |             ANCHORS-XML-LENGTH                                |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   6: ~             ANCHORS-XML                                       ~
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   4: |             ANCHORS-P7S-LENGTH                                |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   6: ~             ANCHORS-P7S                                       ~
+      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+</artwork>
+<t>where</t>
+
+<dl newline="true">
+<dt>OPTION-CODE</dt>
+<dd><t>To be decided</t>
+</dd>
+<dt>OPTION-LENGTH</dt>
+<dd><t>Length of this option excluding the OPTION-CODE and OPTION-LENGTH fields</t>
+</dd>
+<dt>ANCHORS-XML-LENGTH</dt>
+<dd><t>Length of ANCHORS-XML in network byte order</t>
+</dd>
+<dt>ANCHORS-XML</dt>
+<dd><t>Trust anchors in XML format</t>
+</dd>
+<dt>ANCHORS-P7S-LENGTH</dt>
+<dd><t>Length of ANCHORS-P7S in network byte order</t>
+</dd>
+<dt>ANCHORS-P7S</dt>
+<dd><t>Signature in p7s format</t>
+</dd>
+</dl>
+<t>This option provides DNSSEC trust anchors as described in <xref target="RFC7958"></xref>.</t>
+</section>
+
+<section anchor="protocol-specification"><name>Protocol Specification</name>
+
+<section anchor="client-processing"><name>Client Processing</name>
+<t>A stub resolver that wishes to use the PROXY CONTROL Option includes the
+option in all outgoing DNS requests that require privacy. The option
+should be initialized according to the needs of the application.
+In addition the PROXY SCOPE Option can be added. In requests, the Scope
+field is set to undefined.</t>
+<t>If the stub resolver receives a reply without a PROXY CONTROL Option
+included in the reply, then stub resolver has to assume that traffic will
+have Do53 levels of privacy.  Similarly, a lack of a PROXY SCOPE Option
+implies a global scope.</t>
+<t>If the stub resolver receives a BADPROXYPOLICY error then the proxy was
+unable to meet the requirements of the PROXY CONTROL Option.</t>
+
+<section anchor="probing"><name>Probing</name>
+<t>In cases where the stub resolver expects a local DNS proxy, or where the
+stub resolver has (a limited) fall back to more private transports, or
+when the security policy of the application is such that is better to fail
+than send queries over Do53, the stub resolver first sends a probing
+query to verify that the proxy supports the PROXY CONTROL and
+PROXY SCOPE Options.</t>
+<t>This request queries &quot;resolver.arpa&quot; for SOA records.
+The proxy MUST implement this as a
+Special Use Domain Name. The actual response is not important. The
+important part is that the proxy returns PROXY CONTROL and PROXY SCOPE
+Options as described in this document or sets
+the response code to BADPROXYPOLICY if it cannot meet specified policy.</t>
+</section>
+
+<section anchor="trust-anchor"><name>Trust Anchor</name>
+<t>In the ideal case, the host operating system provides applications with a
+secure way to access a DNSSEC trust anchor that is maintained according to
+<xref target="RFC5011"></xref>. However in situations where this is not the case, an application
+can fall back to <xref target="RFC7958"></xref>. However, for short lived processes, there is
+considerable overhead in issuing two HTTP(S) requests to data.iana.org to
+obtain the trust anchor XML file and the signature over the trust anchor.
+For this reason, it makes sense to let the proxy cache this information.</t>
+<t>If the local operating system does not provide a DNSSEC trust anchor, then
+the application can ask the proxy. The stub resolver adds the TRUST ANCHOR
+Option with ANCHORS-XML-LENGTH and ANCHORS-P7S-LENGTH set to zero. If the
+proxy returns both an ANCHORS-XML and an ANCHORS-P7S, then the application
+verifies the trust anchor using the trust anchor certificate (which needs
+to come with the application).</t>
+</section>
+</section>
+
+<section anchor="server-processing"><name>Server Processing</name>
+<t>Proxies are encouraged to cache options that appear in requests under the
+assumption that a stub resolver will send multiple requests. If a proxy
+caches DNS responses then the proxy MUST tag cached responses with the
+properties of the DNS transport. When responding to later requests,
+the proxy returns a cached entry only if the parameters of the DNS transport
+match what is specified in the request.</t>
+<t>When a proxy receives a new set of requirements, the proxy compiles a list of
+addresses to connect to and a list of transports to try per address.
+The proxy SHOULD prefer more private transports over less private ones.</t>
+<t>If the proxy cannot obtain a connection to a recursive resolver in a way that
+matches the provided policy, then the proxy sets the BADPROXYPOLICY
+response code in the reply.</t>
+<t>The proxy MUST implement &quot;resolver.arpa&quot; as a locally served zone.
+Proxies SHOULD respond to all queries with NODATA unless other behavior
+is specified in a different document.</t>
+<t>If the proxy successfully connects to a recursive resolver and receives a
+reply, or the query is for a special use domain name that is handled internally
+in the proxy, then the proxy add a PROXY CONTROL Options dat details the
+connection to the recursive resolver (i.e., the U, UA, or A flag depending
+on encryption and authentication, P and or D for authenticated connections,
+A53, AT, AH2, AH3, or AQ depending on the transport (or none of those for a
+future transport). Furthermore the proxy includes the address it
+connected to, the Domain Name if known, any Service Parameters and
+the outgoing interface name if known.</t>
+<t>If the proxy finds a PROXY SCOPE Option, then it calculates the scope from
+the source address. The proxy adds a PROXY SCOPE Option to a reply and
+sets the value of Scope to the actual scope of the source address of the
+request.</t>
+<t>If the request contains a TRUST ANCHOR Option, then the proxy tries to
+fetch the trust anchor XML and p7s files if it does not have them already.
+If fetching one or both fails then the proxy sets the corresponding
+length to zero. It is not clear how long the proxy can cache this information.
+<xref target="RFC7958"></xref> Does not describe how long these documents can be cache.
+A simple solution is to take the Expires header in the HTTP reply.
+The proxy adds a TRUST ANCHOR Option to the reply.</t>
+</section>
+</section>
+
+<section anchor="connection-between-stub-resolver-and-proxy"><name>Connection Between Stub Resolver And Proxy</name>
+<t>Absent other configuration, a stub resolver that implements this standard
+SHOULD connect to the proxy using Do53 and as remote address either ::1 or
+127.0.0.1. In particular, the stub resolver SHOULD avoid using name
+servers listed in files such as /etc/resolv.conf.</t>
+<t>The reason for this is to simplify the integration of local DNS proxies
+in existing environments. If the stub resolver ignores /etc/resolv.conf
+then the proxy can use that information to connect to recursive resolvers.</t>
+<t>If no DNS server is responding to queries sent using Do53 to ::1 and 127.0.0.1,
+or if the response indicates that this standard is not supported, then
+the stub resolver MAY fall back to traditional configuration methods, such
+as /etc/resolv.conf. However, in that case the stub resolver MUST make
+sure that doing so does not violate the policy set by the application.</t>
+</section>
+
+<section anchor="security-considerations"><name>Security Considerations</name>
+<t>A privacy sensitive application SHOULD first issue a SOA query for
+resolver.arpa to verify that the local proxy supports the options documented
+in the document. If the proxy does not support this document then the
+application can refrain from sending queries that reveal privacy sensitive
+names.</t>
+<t>By setting the interface name, an application can select an outging interface
+on the proxy. Proxies should make sure that a query receives from a
+process that is authorized to do so. By default, a proxy SHOULD allow only
+process on the same host to use this feature. If an unauthorized process
+includes an option with the interface name set, then the proxy SHOULD
+return the BADPROXYPOLICY error.</t>
+</section>
+
+<section anchor="iana-considerations"><name>IANA Considerations</name>
+<t>IANA has assigned the following DNS EDNS0 option codes:</t>
+
+<artwork> Value   Name           Status     Reference
+------- -------------- ---------- -----------
+ TBD     PROXY CONTROL  Standard   RFC xxxx
+ TBD     PROXY SCOPE    Standard   RFC xxxx
+ TBD     TRUST ANCHOR   Standard   RFC xxxx
+</artwork>
+<t>IANA has assigned the following DNS response code as an early allocation
+  per <xref target="RFC7120"></xref>:</t>
+
+<artwork> RCODE    Name             Description                   Reference
+-------- ---------------- ----------------------------- -----------
+ TBD      BADPROXYPOLICY   Unable to conform to policy   RFC xxxx
+</artwork>
+</section>
+
+<section anchor="acknowledgements"><name>Acknowledgements</name>
+<t>Many thanks to Yorgos Thessalonikefs and Willem Toorop for their feedback.</t>
+</section>
+
+</middle>
+
+<back>
+<references><name>Normative References</name>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.2119.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
+</references>
+<references><name>Informative References</name>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.1034.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.1035.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.3493.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.5011.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.5280.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.5625.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.6891.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7120.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7540.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7858.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.7958.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.8484.xml"/>
+<xi:include href="https://xml2rfc.ietf.org/public/rfc/bibxml/reference.RFC.9000.xml"/>
+</references>
+
+</back>
+
+</rfc>

--- a/notes/macos
+++ b/notes/macos
@@ -1,0 +1,14 @@
+networksetup -getdnsservers
+-listallnetworkservices
+-getsearchdomains
+ipconfig getpacket <interface> | grep "domain_name_server"
+en voor <interface> zoiets als eth0
+(13:44:30) willem@nlnetlabs.nl/195b55ba-1cb2-47cc-8927-cd6bd25f5739: muchas gracias
+voor de wifi
+  /System/Library/PrivateFrameworks/Apple80211.framework/Versions/A/Resources/airport -I
+Flush caches:
+        /* dscacheutil on 10.5 an later, lookupd before that */
+        system("dscacheutil -flushcache || lookupd -flushcache || discoveryutil udnsflushcaches");
+        system("discoveryutil mdnsflushcache");
+
+en die utilities weten wellicht ook wat de upstream DNS IP is

--- a/proto1/Makefile
+++ b/proto1/Makefile
@@ -1,0 +1,9 @@
+all:	get80_1
+
+GET80_1_OBJ=get80.o connectbyname.o
+
+get80_1: $(GET80_1_OBJ)
+	$(CC) -o $@ $(GET80_1_OBJ)
+
+clean:
+	rm -f get80_1 $(GET80_1_OBJ)

--- a/proto1/README
+++ b/proto1/README
@@ -1,0 +1,1 @@
+Most basic prototype, just call getaddrinfo, socket, connect

--- a/proto1/connectbyname.c
+++ b/proto1/connectbyname.c
@@ -1,0 +1,61 @@
+/*
+connectbyname.c
+
+Implementation of connectbyname
+*/
+
+#include <string.h>
+#include <netdb.h>
+#include <unistd.h>
+
+#include "connectbyname.h"
+
+int cbn_init(struct cbn_context *cbn_ctx)
+{
+	memset(cbn_ctx, '\0', sizeof(cbn_ctx));
+	return 0;
+}
+
+int connectbyname(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname, int *fdp)
+{
+	int r, s, saved_r;
+	struct addrinfo *res, *tres;
+	struct addrinfo hints;
+
+	memset(&hints, '\0', sizeof(hints));
+	hints.ai_socktype= SOCK_STREAM;
+
+	r= getaddrinfo(hostname, servname, &hints, &res);
+	if (r != 0)
+		return -1;	/* XXX convert error */
+	tres= res;
+	for (tres= res; tres; tres= tres->ai_next)
+	{
+		s= socket(tres->ai_family, tres->ai_socktype,
+			tres->ai_protocol);
+		if (s == -1)
+		{
+			saved_r= -1;	/* Should convert errno */
+			continue;
+		}
+		r= connect(s, tres->ai_addr, tres->ai_addrlen);
+		if (r == -1)
+		{
+			saved_r= -1;	/* Should convert errno */
+			close(s);
+			s= -1;
+			continue;
+		}
+	
+		/* Done */
+		break;
+	}
+	freeaddrinfo(res);
+	if (tres)
+	{
+		*fdp= s;
+		return 0;	/* Success */
+	}
+	return saved_r;
+}

--- a/proto1/connectbyname.h
+++ b/proto1/connectbyname.h
@@ -1,0 +1,15 @@
+/*
+connectbyname.h
+
+Interface for connectbyname
+*/
+
+struct cbn_context
+{
+	int cbn_dummy;
+};
+
+int cbn_init(struct cbn_context *cbn_ctx);
+
+int connectbyname(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname, int *fdp);

--- a/proto1/get80.c
+++ b/proto1/get80.c
@@ -1,0 +1,67 @@
+/*
+get80.c
+
+Send a HTTP GET request to a target and print the result.
+*/
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#include "connectbyname.h"
+
+static void usage(void);
+
+int main(int argc, char *argv[])
+{
+	int r, s;
+	FILE *f;
+	char *hostname;
+	struct cbn_context cbn_ctx;
+	char buf[1024];
+
+	if (argc != 2)
+		usage();
+
+	hostname= argv[1];
+
+	cbn_init(&cbn_ctx);
+	r= connectbyname(&cbn_ctx, hostname, "http", &s);
+	if (r)
+	{
+		fprintf(stderr, "connectbyname failed: %d\n", r);
+		exit(1);
+	}
+
+	f= fdopen(s, "r+");
+	if (f == NULL)
+	{
+		fprintf(stderr, "fdopen failed: %s\n", strerror(errno));
+		exit(1);
+	}
+	fprintf(f, "GET / HTTP/1.1\r\nHost: %s\r\n\r\n", hostname);
+	fflush(f);
+	shutdown(s, SHUT_WR);
+	for(;;)
+	{
+		r= fread(buf, 1, sizeof(buf), f);
+		if (r == 0)
+		{
+			if (feof(f))
+				break;
+			fprintf(stderr, "read error: %s\n", strerror(errno));
+			exit(1);
+		}
+		fwrite(buf, r, 1, stdout);
+	}
+	fclose(f);
+	exit(0);
+}
+
+static void usage(void)
+{
+	fprintf(stderr, "get80 <hostname>\n");
+	exit(1);
+}

--- a/proto2/Makefile
+++ b/proto2/Makefile
@@ -1,0 +1,12 @@
+CFLAGS=-g
+LDFLAGS=-g
+
+all:	get80_2
+
+GET80_2_OBJ=get80.o connectbyname.o
+
+get80_2: $(GET80_2_OBJ)
+	$(CC) -o $@ $(GET80_2_OBJ)
+
+clean:
+	rm -f get80_2 $(GET80_2_OBJ)

--- a/proto2/README
+++ b/proto2/README
@@ -1,0 +1,2 @@
+Simple prototype, call getaddrinfo, then connect using happy eyeballs
+to avoid waiting too long for a connect to fail.

--- a/proto2/connectbyname.c
+++ b/proto2/connectbyname.c
@@ -1,0 +1,360 @@
+/*
+connectbyname.c
+
+Implementation of connectbyname
+*/
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <netdb.h>
+#include <time.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+
+#include "connectbyname.h"
+
+#define MAXADDRS	16
+#define TIMEOUT_NS	25000000	/* 25 ms */
+#undef TIMEOUT_NS
+#define TIMEOUT_NS	5000000	
+
+struct addrlist
+{
+	int timeout;
+	int error;
+	int socket;
+	struct addrinfo *ai;
+	struct timespec endtime;
+};
+
+int cbn_init(struct cbn_context *cbn_ctx)
+{
+	memset(cbn_ctx, '\0', sizeof(cbn_ctx));
+	return 0;
+}
+
+int connectbyname(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname, int *fdp)
+{
+	int i, j, r, s, any, best, done, do_timeout, error, maxfd, 
+		naddrs, prefer_ipv6, saved_r, sock;
+	socklen_t socklen;
+	long nsecdiff;
+	struct addrinfo *res, *tres;
+	struct addrinfo *reslist[MAXADDRS];
+	struct addrlist *ap;
+	struct addrlist alist[MAXADDRS];
+	struct addrinfo hints;
+	char addrstr[INET6_ADDRSTRLEN];
+	fd_set wrset, errset;
+	struct timeval timeout;
+	struct timespec now;
+
+	memset(&hints, '\0', sizeof(hints));
+	hints.ai_socktype= SOCK_STREAM;
+
+	r= getaddrinfo(hostname, servname, &hints, &res);
+	if (r != 0)
+		return -1;	/* XXX convert error */
+
+	/* Copy res entries to reslist */
+	for (naddrs= 0, tres= res; naddrs < MAXADDRS, tres;
+		naddrs++, tres= tres->ai_next)
+	{
+		reslist[naddrs]= tres;
+	}
+
+	printf("before sorting:\n");
+	for (i= 0; i<naddrs; i++)
+	{
+		getnameinfo(reslist[i]->ai_addr, reslist[i]->ai_addrlen, 
+			addrstr, sizeof(addrstr), NULL, 0, NI_NUMERICHOST);
+		printf("%s\n", addrstr);
+	}
+
+	/* Try to interleave IPv4 and IPv6 addresses */
+	prefer_ipv6= 1;
+	for (i= 0; i<naddrs; i++)
+	{
+		alist[i].error= 0;
+		alist[i].socket= -1;
+
+		best= -1;
+		any= -1;
+		for (j= 0; j<naddrs; j++)
+		{
+			tres= reslist[j];
+			if (!tres)
+				continue;
+			if (any == -1)
+				any= j;
+			if (prefer_ipv6)
+			{
+				if (tres->ai_family == AF_INET6)
+				{
+					best= j;
+					prefer_ipv6= 0;	/* IPv4 next time */
+					break;
+				}
+			}
+			else
+			{
+				if (tres->ai_family == AF_INET)
+				{
+					best= j;
+					prefer_ipv6= 1;	/* IPv6 next time */
+					break;
+				}
+			}
+		}
+		if (best != -1)
+		{
+			alist[i].ai= reslist[best];
+			reslist[best]= NULL;
+			continue;
+		}
+		assert(any != -1);
+		alist[i].ai= reslist[any];
+		reslist[any]= NULL;
+	}
+
+	printf("after sorting:\n");
+	for (i= 0; i<naddrs; i++)
+	{
+		getnameinfo(alist[i].ai->ai_addr, alist[i].ai->ai_addrlen, 
+			addrstr, sizeof(addrstr), NULL, 0, NI_NUMERICHOST);
+		printf("%s\n", addrstr);
+	}
+
+	for(;;)
+	{
+		done= 1;	/* Assume we are done. Will be cleared when
+				 * there is work to do.
+				 */
+		FD_ZERO(&wrset);
+		FD_ZERO(&errset);
+		maxfd= 0;
+		do_timeout= 0;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		for (i= 0, ap= alist; i<naddrs; i++, ap++)
+		{
+			fprintf(stderr, "%d: error %d\n", i, ap->error);
+			if (ap->error)
+			{
+				continue;	/* This address already
+						 * failed.
+						 */
+			}
+			fprintf(stderr, "%d: socket %d\n", i, ap->socket);
+
+			if (ap->socket == -1)
+			{
+				r= socket(ap->ai->ai_family,
+					ap->ai->ai_socktype, 
+					ap->ai->ai_protocol);
+				if (r == -1)
+				{
+					ap->error= errno;
+					continue;
+				}
+
+				ap->socket= r;
+
+				/* Switch to nonblocking */
+				fcntl(ap->socket, F_SETFL,
+					fcntl(ap->socket, F_GETFL) |
+					O_NONBLOCK);
+
+				r= connect(ap->socket, ap->ai->ai_addr,
+					ap->ai->ai_addrlen);
+				if (r == 0)
+				{
+					/* This is weird, a nonblocking
+					 * connect that succeeds. In any,
+					 * we got what we wanted.
+					 */
+					done= 1; /* signal that we are done */
+					break;
+				}
+				else if (errno == EINPROGRESS)
+				{
+					/* This is what we expect, fall
+					 * through.
+					 */
+				}
+				else
+				{
+					/* Some kind of error */
+					ap->error= errno;
+					continue;
+				}
+
+				ap->timeout= 0;
+				ap->endtime.tv_sec= now.tv_sec + 
+					TIMEOUT_NS / 1000000000;
+				ap->endtime.tv_nsec= now.tv_nsec +
+					TIMEOUT_NS % 1000000000;
+				if (ap->endtime.tv_nsec >= 1000000000)
+				{
+					ap->endtime.tv_nsec -= 1000000000;
+					ap->endtime.tv_sec++;
+				}
+			}
+
+			assert(ap->socket != -1 && ap->error == 0);
+			FD_SET(ap->socket, &wrset);
+			FD_SET(ap->socket, &errset);
+			if (ap->socket > maxfd)
+				maxfd= ap->socket;
+			done= 0;
+
+			if (!ap->timeout)
+			{
+				if (ap->endtime.tv_sec < now.tv_sec ||
+					(ap->endtime.tv_sec == now.tv_sec &&
+					ap->endtime.tv_nsec <= now.tv_nsec))
+				{
+					/* We got a timeout, move to the
+					 * next address.
+					 */
+					ap->timeout= 1;
+					continue;
+				}
+
+				timeout.tv_sec= ap->endtime.tv_sec-now.tv_sec;
+				nsecdiff= ap->endtime.tv_nsec-now.tv_nsec;
+				if (nsecdiff < 0)
+				{
+					nsecdiff += 1000000000;
+					timeout.tv_sec--;
+				}
+				timeout.tv_usec= nsecdiff/1000+1;
+				do_timeout= 1;
+				break;
+			}
+		}
+
+		if (done)
+		{
+			if (i < naddrs)
+				break;	/* Got something */
+
+			/* All addresses failed. */
+			assert(alist[0].error);
+			break;
+		}
+
+		r= select(maxfd+1, NULL, &wrset, &errset,
+			do_timeout ? &timeout : NULL);
+		fprintf(stderr, "select returned %d\n", r);
+
+		if (r > 0)
+		{
+			/* Just look at all sockets */
+			for (i= 0, ap= alist; i<naddrs; i++, ap++)
+			{
+				if (ap->error)
+					continue;
+				sock= ap->socket;
+				if (sock == -1)
+					continue;
+				if (FD_ISSET(sock, &wrset))
+				{
+					/* Check for error */
+					socklen= sizeof(error);
+					r= getsockopt(sock, SOL_SOCKET,
+						SO_ERROR, &error, &socklen);
+					if (r == -1)
+					{
+						/* Weird */
+						ap->error= errno;
+						continue;
+					}
+					if (error)
+					{
+						ap->error= error;
+						continue;
+					}
+
+					/* No error, got one */
+					break;
+
+				}
+				if (FD_ISSET(sock, &errset))
+				{
+					/* What do we now? */
+					fprintf(stderr, "what about errset?\n");
+					abort();
+				}
+			}
+
+			if (i<naddrs)
+				break;
+		}
+
+		/* Try again */
+	}
+
+	freeaddrinfo(res);
+	sock= -1;
+	if (i < naddrs)
+	{
+		sock= alist[i].socket;
+		alist[i].socket= -1;
+	}
+	for (i= 0, ap= alist; i<naddrs; i++, ap++)
+	{
+		if (ap->socket != -1)
+		{
+			close(ap->socket);
+			ap->socket= -1;
+		}
+	}
+	if (sock != -1)
+	{
+		/* Switch socket back to blocking */
+		fcntl(sock, F_SETFL, fcntl(sock, F_GETFL) & ~O_NONBLOCK);
+		*fdp= sock;
+		return 0;	/* Success */
+	}
+
+	/* Should convert error to result value */
+	return -1;
+	
+#if 0
+	XXX
+	tres= res;
+	for (tres= res; tres; tres= tres->ai_next)
+	{
+		s= socket(tres->ai_family, tres->ai_socktype,
+			tres->ai_protocol);
+		if (s == -1)
+		{
+			saved_r= -1;	/* Should convert errno */
+			continue;
+		}
+		r= connect(s, tres->ai_addr, tres->ai_addrlen);
+		if (r == -1)
+		{
+			saved_r= -1;	/* Should convert errno */
+			close(s);
+			s= -1;
+			continue;
+		}
+	
+		/* Done */
+		break;
+	}
+	freeaddrinfo(res);
+	if (tres)
+	{
+		*fdp= s;
+		return 0;	/* Success */
+	}
+	return saved_r;
+#endif
+}

--- a/proto2/connectbyname.h
+++ b/proto2/connectbyname.h
@@ -1,0 +1,15 @@
+/*
+connectbyname.h
+
+Interface for connectbyname
+*/
+
+struct cbn_context
+{
+	int cbn_dummy;
+};
+
+int cbn_init(struct cbn_context *cbn_ctx);
+
+int connectbyname(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname, int *fdp);

--- a/proto2/get80.c
+++ b/proto2/get80.c
@@ -1,0 +1,67 @@
+/*
+get80.c
+
+Send a HTTP GET request to a target and print the result.
+*/
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#include "connectbyname.h"
+
+static void usage(void);
+
+int main(int argc, char *argv[])
+{
+	int r, s;
+	FILE *f;
+	char *hostname;
+	struct cbn_context cbn_ctx;
+	char buf[1024];
+
+	if (argc != 2)
+		usage();
+
+	hostname= argv[1];
+
+	cbn_init(&cbn_ctx);
+	r= connectbyname(&cbn_ctx, hostname, "http", &s);
+	if (r)
+	{
+		fprintf(stderr, "connectbyname failed: %d\n", r);
+		exit(1);
+	}
+
+	f= fdopen(s, "r+");
+	if (f == NULL)
+	{
+		fprintf(stderr, "fdopen failed: %s\n", strerror(errno));
+		exit(1);
+	}
+	fprintf(f, "GET / HTTP/1.1\r\nHost: %s\r\n\r\n", hostname);
+	fflush(f);
+	shutdown(s, SHUT_WR);
+	for(;;)
+	{
+		r= fread(buf, 1, sizeof(buf), f);
+		if (r == 0)
+		{
+			if (feof(f))
+				break;
+			fprintf(stderr, "read error: %s\n", strerror(errno));
+			exit(1);
+		}
+		fwrite(buf, r, 1, stdout);
+	}
+	fclose(f);
+	exit(0);
+}
+
+static void usage(void)
+{
+	fprintf(stderr, "get80 <hostname>\n");
+	exit(1);
+}

--- a/proto3/Makefile
+++ b/proto3/Makefile
@@ -1,0 +1,17 @@
+LIBEVENT=/home/philip/src/libevent-2.1.11-stable
+
+CFLAGS=-g -I$(LIBEVENT)/include
+LDFLAGS=-static -g -L$(LIBEVENT)/.libs
+LDFLAGS=-g -L$(LIBEVENT)/.libs
+LIBS=-levent #-levent_pthreads -lpthread
+
+
+all:	get80_3
+
+GET80_3_OBJ=get80.o connectbyname.o
+
+get80_3: $(GET80_3_OBJ)
+	$(CC) $(LDFLAGS) -o $@ $(GET80_3_OBJ) $(LIBS)
+
+clean:
+	rm -f get80_3 $(GET80_3_OBJ)

--- a/proto3/README
+++ b/proto3/README
@@ -1,0 +1,3 @@
+Prototype based on libevent, call evdns_base_resolve_ipv4 and
+evdns_base_resolve_ipv6, then connect using happy eyeballs to avoid waiting
+too long for a connect to fail.

--- a/proto3/connectbyname.c
+++ b/proto3/connectbyname.c
@@ -1,0 +1,969 @@
+/*
+connectbyname.c
+
+Implementation of connectbyname
+*/
+
+#if 0
+#include <errno.h>
+#include <stdio.h>
+#include <time.h>
+#include <arpa/inet.h>
+#endif
+
+#include <assert.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <event2/event.h>
+#include <event2/dns.h>
+
+#include "connectbyname.h"
+
+#define MAXADDRS	16
+#define TIMEOUT_NS	  25000000	/* 25 ms */
+#if 1
+#undef TIMEOUT_NS
+#define TIMEOUT_NS	5000000000	
+#endif
+#define US_PER_SEC	   1000000	/* Microseconds in a second */
+#define NS_PER_SEC	1000000000	/* Nanoseconds in a second */
+
+struct addrlist
+{
+	int timeout;
+	int error;
+	int socket;
+	int selected;
+	struct sockaddr_storage addr;
+	socklen_t addrlen;
+	struct timespec endtime;
+	struct event *event;
+};
+
+struct work_ctx
+{
+	unsigned port;			/* Port number to connect to */
+	void (*user_cb)(int fd, void *ref);
+	void *user_ref;
+
+	unsigned state;
+	struct evdns_request *evdns_ipv4;
+	struct evdns_request *evdns_ipv6;
+	struct addrlist alist[MAXADDRS];
+	unsigned naddrs;
+	struct addrlist *mlist[MAXADDRS];
+
+	/* If IPv4 address arrive first, we wait a bit for the IPv6 addresses
+	 * to arrive. If the time expires, we start connecting to the IPv4
+	 * addresses.
+	 */
+	struct event *ipv6_to_event;
+	struct timespec ipv6_timeout;
+
+	/* Event for connect timeout */
+	struct event *connect_to_event;
+
+	struct cbn_context *base;
+};
+
+#define STATE_INITIAL			0
+#define STATE_DNS			1
+#define STATE_DNS_IPV4_CONNECTING	2
+#define STATE_DNS_IPV6_WAITING		3
+#define STATE_DNS_IPV6_CONNECTING	4
+#define STATE_CONNECTING		5
+
+static void dns_callback(int result, char type, int count, int ttl, 
+	void *addresses, void *arg);
+static void timeout_callback(evutil_socket_t fd, short events, void *ref);
+static void connect_callback(evutil_socket_t fd, short events, void *ref);
+static void connect_to_callback(evutil_socket_t fd, short events, void *ref);
+static void merge_v4_v6(struct work_ctx *ctxp);
+static void do_connect(struct work_ctx *ctxp);
+static void ts_add_ns(struct timespec *tsp, long ns);
+static void ts_sub(struct timespec *res,
+	struct timespec *v1, struct timespec *v2);
+static void tv_from_ts(struct timeval *tv, struct timespec *ts);
+
+int cbn_init(struct cbn_context *cbn_ctx, struct event_base *event_base)
+{
+	memset(cbn_ctx, '\0', sizeof(*cbn_ctx));
+	cbn_ctx->event_base= event_base;
+	return 0;
+}
+
+int connectbyname_asyn(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname,
+	void (*user_cb)(int fd, void *ref), void *user_ref, void **refp)
+{
+	int flags;
+	unsigned long port_ul;
+	char *next;
+	struct servent *se;
+	struct work_ctx *work_ctx;
+
+	/* Parse servname */
+	port_ul= strtoul(servname, &next, 10);
+	if (next[0] == '\0')
+	{
+		if (port_ul == 0 || port_ul >= 0x10000)
+		{
+			/* XXX should convert error */
+			return -1;
+		}
+		port_ul= htons(port_ul);
+	}
+	else
+	{
+		se= getservbyname(servname, "tcp");
+		if (se == NULL)
+			return -1;	/* XXX convert error */
+		port_ul= se->s_port;
+	}
+
+	assert(cbn_ctx->event_base);
+	if (!cbn_ctx->evdns_base)
+	{
+		cbn_ctx->evdns_base= evdns_base_new(cbn_ctx->event_base, EVDNS_BASE_INITIALIZE_NAMESERVERS);
+
+		/* Should check for failure */
+	}
+
+	work_ctx= malloc(sizeof(*work_ctx));
+	memset(work_ctx, '\0', sizeof(*work_ctx));
+	work_ctx->base= cbn_ctx;
+	work_ctx->port= port_ul;
+	work_ctx->user_cb= user_cb;
+	work_ctx->user_ref= user_ref;
+
+	work_ctx->state= STATE_INITIAL;
+
+	work_ctx->state= STATE_DNS;
+
+	flags= 0;
+	work_ctx->evdns_ipv4= evdns_base_resolve_ipv4(cbn_ctx->evdns_base,
+		hostname, flags, dns_callback, work_ctx);
+	work_ctx->evdns_ipv6= evdns_base_resolve_ipv6(cbn_ctx->evdns_base,
+		hostname, flags, dns_callback, work_ctx);
+
+	*refp= work_ctx;
+	return 0;
+
+#if 0
+	int i, j, r, s, any, best, done, do_timeout, error, maxfd, 
+		naddrs, prefer_ipv6, saved_r, sock;
+	socklen_t socklen;
+	long nsecdiff;
+	struct addrinfo *res, *tres;
+	struct addrinfo *reslist[MAXADDRS];
+	struct addrlist *ap;
+	struct addrinfo hints;
+	char addrstr[INET6_ADDRSTRLEN];
+	fd_set wrset, errset;
+	struct timeval timeout;
+	struct timespec now;
+
+	memset(&hints, '\0', sizeof(hints));
+	hints.ai_socktype= SOCK_STREAM;
+
+	r= getaddrinfo(hostname, servname, &hints, &res);
+	if (r != 0)
+		return -1;	/* XXX convert error */
+
+	/* Copy res entries to reslist */
+	for (naddrs= 0, tres= res; naddrs < MAXADDRS, tres;
+		naddrs++, tres= tres->ai_next)
+	{
+		reslist[naddrs]= tres;
+	}
+
+	printf("before sorting:\n");
+	for (i= 0; i<naddrs; i++)
+	{
+		getnameinfo(reslist[i]->ai_addr, reslist[i]->ai_addrlen, 
+			addrstr, sizeof(addrstr), NULL, 0, NI_NUMERICHOST);
+		printf("%s\n", addrstr);
+	}
+
+	/* Try to interleave IPv4 and IPv6 addresses */
+	prefer_ipv6= 1;
+	for (i= 0; i<naddrs; i++)
+	{
+		alist[i].error= 0;
+		alist[i].socket= -1;
+
+		best= -1;
+		any= -1;
+		for (j= 0; j<naddrs; j++)
+		{
+			tres= reslist[j];
+			if (!tres)
+				continue;
+			if (any == -1)
+				any= j;
+			if (prefer_ipv6)
+			{
+				if (tres->ai_family == AF_INET6)
+				{
+					best= j;
+					prefer_ipv6= 0;	/* IPv4 next time */
+					break;
+				}
+			}
+			else
+			{
+				if (tres->ai_family == AF_INET)
+				{
+					best= j;
+					prefer_ipv6= 1;	/* IPv6 next time */
+					break;
+				}
+			}
+		}
+		if (best != -1)
+		{
+			alist[i].ai= reslist[best];
+			reslist[best]= NULL;
+			continue;
+		}
+		assert(any != -1);
+		alist[i].ai= reslist[any];
+		reslist[any]= NULL;
+	}
+
+	printf("after sorting:\n");
+	for (i= 0; i<naddrs; i++)
+	{
+		getnameinfo(alist[i].ai->ai_addr, alist[i].ai->ai_addrlen, 
+			addrstr, sizeof(addrstr), NULL, 0, NI_NUMERICHOST);
+		printf("%s\n", addrstr);
+	}
+
+	for(;;)
+	{
+		done= 1;	/* Assume we are done. Will be cleared when
+				 * there is work to do.
+				 */
+		FD_ZERO(&wrset);
+		FD_ZERO(&errset);
+		maxfd= 0;
+		do_timeout= 0;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		for (i= 0, ap= alist; i<naddrs; i++, ap++)
+		{
+			fprintf(stderr, "%d: error %d\n", i, ap->error);
+			if (ap->error)
+			{
+				continue;	/* This address already
+						 * failed.
+						 */
+			}
+			fprintf(stderr, "%d: socket %d\n", i, ap->socket);
+
+			if (ap->socket == -1)
+			{
+				r= socket(ap->ai->ai_family,
+					ap->ai->ai_socktype, 
+					ap->ai->ai_protocol);
+				if (r == -1)
+				{
+					ap->error= errno;
+					continue;
+				}
+
+				ap->socket= r;
+
+				/* Switch to nonblocking */
+				fcntl(ap->socket, F_SETFL,
+					fcntl(ap->socket, F_GETFL) |
+					O_NONBLOCK);
+
+				r= connect(ap->socket, ap->ai->ai_addr,
+					ap->ai->ai_addrlen);
+				if (r == 0)
+				{
+					/* This is weird, a nonblocking
+					 * connect that succeeds. In any,
+					 * we got what we wanted.
+					 */
+					done= 1; /* signal that we are done */
+					break;
+				}
+				else if (errno == EINPROGRESS)
+				{
+					/* This is what we expect, fall
+					 * through.
+					 */
+				}
+				else
+				{
+					/* Some kind of error */
+					ap->error= errno;
+					continue;
+				}
+
+				ap->timeout= 0;
+				ap->endtime.tv_sec= now.tv_sec + 
+					TIMEOUT_NS / NS_PER_SEC;
+				ap->endtime.tv_nsec= now.tv_nsec +
+					TIMEOUT_NS % NS_PER_SEC;
+				if (ap->endtime.tv_nsec >= NS_PER_SEC)
+				{
+					ap->endtime.tv_nsec -= NS_PER_SEC;
+					ap->endtime.tv_sec++;
+				}
+			}
+
+			assert(ap->socket != -1 && ap->error == 0);
+			FD_SET(ap->socket, &wrset);
+			FD_SET(ap->socket, &errset);
+			if (ap->socket > maxfd)
+				maxfd= ap->socket;
+			done= 0;
+
+			if (!ap->timeout)
+			{
+				if (ap->endtime.tv_sec < now.tv_sec ||
+					(ap->endtime.tv_sec == now.tv_sec &&
+					ap->endtime.tv_nsec <= now.tv_nsec))
+				{
+					/* We got a timeout, move to the
+					 * next address.
+					 */
+					ap->timeout= 1;
+					continue;
+				}
+
+				timeout.tv_sec= ap->endtime.tv_sec-now.tv_sec;
+				nsecdiff= ap->endtime.tv_nsec-now.tv_nsec;
+				if (nsecdiff < 0)
+				{
+					nsecdiff += NS_PER_SEC;
+					timeout.tv_sec--;
+				}
+				timeout.tv_usec= nsecdiff/1000+1;
+				do_timeout= 1;
+				break;
+			}
+		}
+
+		if (done)
+		{
+			if (i < naddrs)
+				break;	/* Got something */
+
+			/* All addresses failed. */
+			assert(alist[0].error);
+			break;
+		}
+
+		r= select(maxfd+1, NULL, &wrset, &errset,
+			do_timeout ? &timeout : NULL);
+		fprintf(stderr, "select returned %d\n", r);
+
+		if (r > 0)
+		{
+			/* Just look at all sockets */
+			for (i= 0, ap= alist; i<naddrs; i++, ap++)
+			{
+				if (ap->error)
+					continue;
+				sock= ap->socket;
+				if (sock == -1)
+					continue;
+				if (FD_ISSET(sock, &wrset))
+				{
+					/* Check for error */
+					socklen= sizeof(error);
+					r= getsockopt(sock, SOL_SOCKET,
+						SO_ERROR, &error, &socklen);
+					if (r == -1)
+					{
+						/* Weird */
+						ap->error= errno;
+						continue;
+					}
+					if (error)
+					{
+						ap->error= error;
+						continue;
+					}
+
+					/* No error, got one */
+					break;
+
+				}
+				if (FD_ISSET(sock, &errset))
+				{
+					/* What do we now? */
+					fprintf(stderr, "what about errset?\n");
+					abort();
+				}
+			}
+
+			if (i<naddrs)
+				break;
+		}
+
+		/* Try again */
+	}
+
+	freeaddrinfo(res);
+	sock= -1;
+	if (i < naddrs)
+	{
+		sock= alist[i].socket;
+		alist[i].socket= -1;
+	}
+	for (i= 0, ap= alist; i<naddrs; i++, ap++)
+	{
+		if (ap->socket != -1)
+		{
+			close(ap->socket);
+			ap->socket= -1;
+		}
+	}
+	if (sock != -1)
+	{
+		/* Switch socket back to blocking */
+		fcntl(sock, F_SETFL, fcntl(sock, F_GETFL) & ~O_NONBLOCK);
+		*fdp= sock;
+		return 0;	/* Success */
+	}
+
+	/* Should convert error to result value */
+	return -1;
+#endif
+}
+
+static void dns_callback(int result, char type, int count, int ttl, 
+	void *addresses, void *arg)
+{
+	int i;
+	struct work_ctx *ctxp;
+	struct sockaddr_in *sin4p;
+	struct sockaddr_in6 *sin6p;
+	struct addrlist *alist;
+	uint8_t (*addrs4)[4];
+	uint8_t (*addrs6)[16];
+	struct timespec timeout;
+	char addrstr[INET6_ADDRSTRLEN];
+
+	ctxp= arg;
+	if (result != DNS_ERR_NONE)
+	{
+		/* Should handle DNS errors */
+		fprintf(stderr, "dns_callback, result %d\n", result);
+		return;
+	}
+	switch(type)
+	{
+	case DNS_IPv4_A:
+		addrs4= addresses;
+		for (i= 0, alist= &ctxp->alist[ctxp->naddrs]; i<count;
+			i++, alist++)
+		{
+			if (ctxp->naddrs >= MAXADDRS)
+				break;
+
+			alist->error= 0;
+			alist->socket= -1;
+
+			sin4p= (struct sockaddr_in *)&alist->addr;
+			memset(sin4p, '\0', sizeof(*sin4p));
+			sin4p->sin_family= AF_INET;
+			memcpy(&sin4p->sin_addr, addrs4[i],
+				sizeof(sin4p->sin_addr));
+			sin4p->sin_port= ctxp->port;
+			alist->addrlen= sizeof(*sin4p);
+			ctxp->naddrs++;
+		}
+
+		merge_v4_v6(ctxp);
+
+		switch(ctxp->state)
+		{
+		case STATE_DNS:
+			ctxp->state= STATE_DNS_IPV6_WAITING;
+			ctxp->ipv6_to_event= evtimer_new(ctxp->base->event_base,
+				timeout_callback, ctxp);
+			clock_gettime(CLOCK_MONOTONIC, &timeout);
+			fprintf(stderr, "dns_callback: now %d.%09d\n",
+				timeout.tv_sec, timeout.tv_nsec);
+			timeout.tv_nsec += TIMEOUT_NS % NS_PER_SEC;
+			timeout.tv_sec += TIMEOUT_NS / NS_PER_SEC;
+			fprintf(stderr, "dns_callback: timeout %d.%09d\n",
+				timeout.tv_sec, timeout.tv_nsec);
+			if (timeout.tv_nsec >= NS_PER_SEC)
+			{
+				timeout.tv_nsec -= NS_PER_SEC;
+				timeout.tv_sec++;
+			}
+			fprintf(stderr, "dns_callback: timeout %d.%09d\n",
+				timeout.tv_sec, timeout.tv_nsec);
+			ctxp->ipv6_timeout= timeout;
+
+			/* The timeout callback will set the timer. */
+			timeout_callback(-1, 0, ctxp);
+			break;
+
+		case STATE_DNS_IPV4_CONNECTING:
+			ctxp->state= STATE_CONNECTING;
+
+			fprintf(stderr,
+			"dns_callback: before do_connect, addresses:\n");
+			for (i= 0; i<ctxp->naddrs; i++)
+			{
+				getnameinfo((struct sockaddr *)
+					&ctxp->mlist[i]->addr,
+					ctxp->mlist[i]->addrlen, 
+					addrstr, sizeof(addrstr), NULL, 0,
+					NI_NUMERICHOST);
+				fprintf(stderr, "%s\n", addrstr);
+			}
+			do_connect(ctxp);
+			break;
+
+		default:
+			fprintf(stderr,
+				"dns_callback: unknown state %d (IPv4)\n",
+				ctxp->state);
+			return;
+		}
+
+		break;
+
+	case DNS_IPv6_AAAA:
+		addrs6= addresses;
+		for (i= 0, alist= &ctxp->alist[ctxp->naddrs]; i<count;
+			i++, alist++)
+		{
+			if (ctxp->naddrs >= MAXADDRS)
+				break;
+
+			alist->error= 0;
+			alist->socket= -1;
+
+			sin6p= (struct sockaddr_in6 *)&alist->addr;
+			memset(sin6p, '\0', sizeof(*sin6p));
+			sin6p->sin6_family= AF_INET6;
+			memcpy(&sin6p->sin6_addr, addrs6[i],
+				sizeof(sin6p->sin6_addr));
+			sin6p->sin6_port= ctxp->port;
+			alist->addrlen= sizeof(*sin6p);
+			ctxp->naddrs++;
+		}
+
+		merge_v4_v6(ctxp);
+
+		switch(ctxp->state)
+		{
+		case STATE_DNS:
+			ctxp->state= STATE_DNS_IPV4_CONNECTING;
+			fprintf(stderr,
+			"dns_callback: before do_connect, addresses:\n");
+			for (i= 0; i<ctxp->naddrs; i++)
+			{
+				getnameinfo((struct sockaddr *)
+					&ctxp->mlist[i]->addr,
+					ctxp->mlist[i]->addrlen, 
+					addrstr, sizeof(addrstr), NULL, 0,
+					NI_NUMERICHOST);
+				fprintf(stderr, "%s\n", addrstr);
+			}
+			do_connect(ctxp);
+			break;
+
+		case STATE_DNS_IPV6_WAITING:
+			/* Cancel timer */
+			evtimer_del(ctxp->ipv6_to_event);
+			event_free(ctxp->ipv6_to_event);
+			ctxp->ipv6_to_event= NULL;
+			ctxp->state= STATE_CONNECTING;
+			fprintf(stderr,
+			"dns_callback: before do_connect, addresses:\n");
+			for (i= 0; i<ctxp->naddrs; i++)
+			{
+				getnameinfo((struct sockaddr *)
+					&ctxp->mlist[i]->addr,
+					ctxp->mlist[i]->addrlen, 
+					addrstr, sizeof(addrstr), NULL, 0,
+					NI_NUMERICHOST);
+				fprintf(stderr, "%s\n", addrstr);
+			}
+			do_connect(ctxp);
+			break;
+			
+		default:
+			fprintf(stderr,
+			"dns_callback: unknown state %d (IPv6)\n",
+				ctxp->state);
+			return;
+		}
+
+		break;
+
+	default:
+		fprintf(stderr, "dns_callback; unknown type %d\n", type);
+		return;
+	}
+}
+
+static void timeout_callback(evutil_socket_t fd, short events, void *ref)
+{
+	struct work_ctx *ctxp;
+	struct timespec now;
+	struct timeval timeout;
+
+	ctxp= ref;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	fprintf(stderr, "timeout_callback: now %d.%09d\n",
+		now.tv_sec, now.tv_nsec);
+	fprintf(stderr, "timeout_callback: target %d.%09d\n",
+		ctxp->ipv6_timeout.tv_sec, ctxp->ipv6_timeout.tv_nsec);
+
+	if (now.tv_sec < ctxp->ipv6_timeout.tv_sec ||
+		(now.tv_sec == ctxp->ipv6_timeout.tv_sec &&
+		now.tv_nsec < ctxp->ipv6_timeout.tv_nsec))
+	{
+		/* Set timer */
+		timeout.tv_sec= ctxp->ipv6_timeout.tv_sec - now.tv_sec;
+		timeout.tv_usec= (ctxp->ipv6_timeout.tv_nsec - now.tv_nsec)/
+			1000 + 1;
+
+		fprintf(stderr, "timeout %d.%06d\n",
+			timeout.tv_sec, timeout.tv_usec);
+		if (timeout.tv_usec < 0)
+		{
+			timeout.tv_usec += US_PER_SEC;
+			timeout.tv_sec--;
+		}
+		fprintf(stderr, "timeout %d.%06d\n",
+			timeout.tv_sec, timeout.tv_usec);
+		evtimer_add(ctxp->ipv6_to_event, &timeout);
+		return;
+	}
+
+	/* The state should be STATE_DNS_IPV6_WAITING. Ignore other states */
+	if (ctxp->state != STATE_DNS_IPV6_WAITING)
+	{
+		fprintf(stderr, "timeout_callback: bad state %d\n",
+			ctxp->state);
+		return;
+	}
+
+	/* Start connecting */
+	ctxp->state= STATE_DNS_IPV6_CONNECTING;
+	do_connect(ctxp);
+}
+
+static void connect_callback(evutil_socket_t fd, short events, void *ref)
+{
+	int i, r, error, sock;
+	socklen_t socklen;
+	struct work_ctx *ctxp;
+	struct addrlist *ap;
+	void (*user_cb)(int fd, void *ref);
+	void *user_ref;
+
+	ctxp= ref;
+
+	/* Just look at all sockets */
+	for (i= 0, ap= ctxp->alist; i<ctxp->naddrs; i++, ap++)
+	{
+		if (ap->socket == fd)
+			break;
+	}
+
+	if (i >= ctxp->naddrs)
+	{
+		/* Weird. */
+		fprintf(stderr, "connect_callback: socket not found\n");
+		return;
+
+	}
+
+	/* Check for error */
+	socklen= sizeof(error);
+	r= getsockopt(fd, SOL_SOCKET, SO_ERROR, &error, &socklen);
+	if (r == -1)
+	{
+		/* Weird */
+		ap->error= errno;
+		do_connect(ctxp);
+		return;
+	}
+	if (error)
+	{
+		ap->error= error;
+		do_connect(ctxp);
+		return;
+	}
+
+	sock= ap->socket;
+	ap->socket= -1;
+
+	assert(ap->event);
+	event_del(ap->event);
+	event_free(ap->event);
+	ap->event= NULL;
+
+	/* Kill timers */
+	if (ctxp->ipv6_to_event)
+	{
+		evtimer_del(ctxp->ipv6_to_event);
+		event_free(ctxp->ipv6_to_event);
+		ctxp->ipv6_to_event= NULL;
+	}
+
+	assert(ctxp->connect_to_event);
+	evtimer_del(ctxp->connect_to_event);
+	event_free(ctxp->connect_to_event);
+	ctxp->connect_to_event= NULL;
+
+	for (i= 0, ap= ctxp->alist; i<ctxp->naddrs; i++, ap++)
+	{
+		if (ap->socket == -1)
+			continue;
+
+		assert(ap->event);
+		event_del(ap->event);
+		event_free(ap->event);
+		ap->event= NULL;
+
+		close(ap->socket);
+		ap->socket= -1;
+	}
+
+	/* Should deal with 
+	struct evdns_request *evdns_ipv4;
+	struct evdns_request *evdns_ipv6;
+	*/
+
+	user_cb= ctxp->user_cb;
+	user_ref= ctxp->user_ref;
+
+	/* Should free ctxp */
+
+	(*user_cb)(sock, user_ref);
+}
+
+static void connect_to_callback(evutil_socket_t fd, short events, void *ref)
+{
+	struct work_ctx *ctxp;
+
+	ctxp= ref;
+
+	fprintf(stderr, "connect_to_callback: restarting connect\n");
+	do_connect(ctxp);
+}
+
+static void merge_v4_v6(struct work_ctx *ctxp)
+{
+	int i, j, any, best, prefer_ipv6;
+	struct addrlist *ap;
+
+	for (i= 0, ap= ctxp->alist; i<ctxp->naddrs; i++, ap++)
+		ap->selected= 0;
+
+	/* Try to interleave IPv4 and IPv6 addresses */
+	prefer_ipv6= 1;
+	for (i= 0; i<ctxp->naddrs; i++)
+	{
+		best= -1;
+		any= -1;
+		for (j= 0, ap= ctxp->alist; j<ctxp->naddrs; j++, ap++)
+		{
+			if (ap->selected)
+				continue;
+
+			if (any == -1)
+				any= j;
+			if (prefer_ipv6)
+			{
+				if (ap->addr.ss_family == AF_INET6)
+				{
+					best= j;
+					prefer_ipv6= 0;	/* IPv4 next time */
+					break;
+				}
+			}
+			else
+			{
+				if (ap->addr.ss_family == AF_INET)
+				{
+					best= j;
+					prefer_ipv6= 1;	/* IPv6 next time */
+					break;
+				}
+			}
+		}
+		if (best != -1)
+		{
+			ctxp->mlist[i]= &ctxp->alist[best];
+			ctxp->alist[best].selected= 1;
+			continue;
+		}
+		assert(any != -1);
+		ctxp->mlist[i]= &ctxp->alist[any];
+		ctxp->alist[any].selected= 1;
+	}
+}
+
+static void do_connect(struct work_ctx *ctxp)
+{
+	int i, r, done, do_timeout;
+	struct addrlist *ap;
+	struct timespec now, timeout_ns;
+	struct timeval timeout;
+
+	done= 1;	/* Assume we are done. Will be cleared when
+			 * there is work to do.
+			 */
+	do_timeout= 0;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	for (i= 0; i<ctxp->naddrs; i++)
+	{
+		ap= ctxp->mlist[i];
+
+		if (ap->error)
+		{
+			continue;	/* This address already
+					 * failed.
+					 */
+		}
+
+		if (ap->socket == -1)
+		{
+			r= socket(ap->addr.ss_family, SOCK_STREAM, 0);
+			if (r == -1)
+			{
+				ap->error= errno;
+				continue;
+			}
+
+			ap->socket= r;
+
+			/* Switch to nonblocking */
+			fcntl(ap->socket, F_SETFL,
+				fcntl(ap->socket, F_GETFL) |
+				O_NONBLOCK);
+
+			r= connect(ap->socket, (struct sockaddr *)&ap->addr,
+				ap->addrlen);
+			if (r == 0)
+			{
+				/* This is weird, a nonblocking
+				 * connect that succeeds. In any case,
+				 * we got what we wanted.
+				 */
+				done= 1; /* signal that we are done */
+				break;
+			}
+			else if (errno == EINPROGRESS)
+			{
+				/* This is what we expect, fall
+				 * through.
+				 */
+			}
+			else
+			{
+				/* Some kind of error */
+				ap->error= errno;
+				continue;
+			}
+
+			ap->timeout= 0;
+			ap->endtime= now;
+			ts_add_ns(&ap->endtime, TIMEOUT_NS);
+
+			assert(!ap->event);
+			ap->event= event_new(ctxp->base->event_base,
+				ap->socket, EV_WRITE, connect_callback, ctxp);
+			event_add(ap->event, NULL);
+		}
+
+		assert(ap->socket != -1 && ap->error == 0);
+		done= 0;
+
+		if (!ap->timeout)
+		{
+			if (ap->endtime.tv_sec < now.tv_sec ||
+				(ap->endtime.tv_sec == now.tv_sec &&
+				ap->endtime.tv_nsec <= now.tv_nsec))
+			{
+				/* We got a timeout, move to the
+				 * next address.
+				 */
+				ap->timeout= 1;
+				continue;
+			}
+
+			ts_sub(&timeout_ns, &ap->endtime, &now);
+			tv_from_ts(&timeout, &timeout_ns);
+			do_timeout= 1;
+			break;
+		}
+	}
+
+	if (done)
+	{
+		if (i < ctxp->naddrs)
+		{
+			fprintf(stderr, "do_connect: found one\n");
+			return;	/* Got something */
+		}
+
+		/* All addresses failed. */
+		fprintf(stderr, "do_connect: all failed\n");
+		assert(ctxp->alist[0].error);
+		return;
+	}
+
+	if (do_timeout)
+	{
+		if (!ctxp->connect_to_event)
+		{
+			ctxp->connect_to_event=
+				evtimer_new(ctxp->base->event_base,
+				connect_to_callback, ctxp);
+		}
+		evtimer_add(ctxp->connect_to_event, &timeout);
+	}
+
+}
+
+static void ts_add_ns(struct timespec *tsp, long ns)
+{
+	tsp->tv_sec += TIMEOUT_NS / NS_PER_SEC;
+	tsp->tv_nsec += TIMEOUT_NS % NS_PER_SEC;
+	if (tsp->tv_nsec >= NS_PER_SEC)
+	{
+		tsp->tv_nsec -= NS_PER_SEC;
+		tsp->tv_sec++;
+	}
+}
+
+static void ts_sub(struct timespec *res,
+	struct timespec *v1, struct timespec *v2)
+{
+	res->tv_sec= v1->tv_sec-v2->tv_sec;
+	res->tv_nsec= v1->tv_nsec-v2->tv_nsec;
+	if (res->tv_nsec < 0)
+	{
+		res->tv_nsec += NS_PER_SEC;
+		res->tv_sec--;
+	}
+}
+
+static void tv_from_ts(struct timeval *tv, struct timespec *ts)
+{
+	tv->tv_sec= ts->tv_sec;
+	tv->tv_usec= ts->tv_nsec/1000;
+	if (ts->tv_nsec % 1000)
+		tv->tv_usec++;	/* Round up */
+}

--- a/proto3/connectbyname.h
+++ b/proto3/connectbyname.h
@@ -1,0 +1,20 @@
+/*
+connectbyname.h
+
+Interface for connectbyname
+*/
+
+struct cbn_context
+{
+	struct event_base *event_base;
+	struct evdns_base *evdns_base;
+};
+
+int cbn_init(struct cbn_context *cbn_ctx, struct event_base *event_base);
+
+int connectbyname(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname, int *fdp);
+
+int connectbyname_asyn(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname,
+	void (*user_cb)(int fd, void *ref), void *user_ref, void **refp);

--- a/proto3/get80.c
+++ b/proto3/get80.c
@@ -1,0 +1,135 @@
+/*
+get80.c
+
+Send a HTTP GET request to a target and print the result.
+*/
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+
+#include <event2/event.h>
+
+#include "connectbyname.h"
+
+struct state
+{
+	char *hostname;
+	struct event_base *event_base;
+	struct event *event;
+};
+
+static void callback(int fd, void *ref);
+static void read_callback(int fd, short events, void *ref);
+static void usage(void);
+
+int main(int argc, char *argv[])
+{
+	int r, s;
+	FILE *f;
+	char *hostname;
+	void *ref;
+	struct event_base *event_base;
+	struct cbn_context cbn_ctx;
+	char buf[1024];
+	struct state state;
+
+	if (argc != 2)
+		usage();
+
+	hostname= argv[1];
+	state.hostname= hostname;
+
+	event_enable_debug_mode();
+	event_base= event_base_new();
+	state.event_base= event_base;
+	cbn_init(&cbn_ctx, event_base);
+	r= connectbyname_asyn(&cbn_ctx, hostname, "http", callback, &state,
+		&ref);
+	if (r)
+	{
+		fprintf(stderr, "connectbyname failed: %d\n", r);
+		exit(1);
+	}
+
+	r= event_base_dispatch(event_base);
+	fprintf(stderr, "event_base_dispatch returned: %d\n", r);
+	abort();
+
+	f= fdopen(s, "r+");
+	if (f == NULL)
+	{
+		fprintf(stderr, "fdopen failed: %s\n", strerror(errno));
+		exit(1);
+	}
+	fprintf(f, "GET / HTTP/1.1\r\nHost: %s\r\n\r\n", hostname);
+	fflush(f);
+	shutdown(s, SHUT_WR);
+	for(;;)
+	{
+		r= fread(buf, 1, sizeof(buf), f);
+		if (r == 0)
+		{
+			if (feof(f))
+				break;
+			fprintf(stderr, "read error: %s\n", strerror(errno));
+			exit(1);
+		}
+		fwrite(buf, r, 1, stdout);
+	}
+	fclose(f);
+	exit(0);
+}
+
+static void callback(int fd, void *ref)
+{
+	struct state *statep;
+	char reqline[80];
+
+	statep= ref;
+
+	snprintf(reqline, sizeof(reqline),
+		"GET / HTTP/1.1\r\nHost: %s\r\n\r\n", statep->hostname);
+	
+	/* Assume write will not block */
+	write(fd, reqline, strlen(reqline));
+
+	statep->event= event_new(statep->event_base, fd, EV_READ | EV_PERSIST,
+		read_callback, statep);
+	event_add(statep->event, NULL);
+}
+
+static void read_callback(int fd, short events, void *ref)
+{
+	int r;
+	char line[1024];
+
+	if (events != EV_READ)
+	{
+		fprintf(stderr, "read_callback: bad events value 0x%x\n",
+			events);
+		exit(1);
+	}
+
+	r= read(fd, line, sizeof(line));
+	if (r == 0)
+	{
+		/* EOF */
+		exit(0);
+	}
+	if (r == -1)
+	{
+		fprintf(stderr, "read error %s\n", strerror(errno));
+		exit(1);
+	}
+	printf("%.*s", r, line);
+}
+
+static void usage(void)
+{
+	fprintf(stderr, "get80 <hostname>\n");
+	exit(1);
+}

--- a/proto4/Makefile
+++ b/proto4/Makefile
@@ -1,0 +1,17 @@
+LIBEVENT=/home/philip/src/libevent-2.1.11-stable
+
+CFLAGS=-g -I$(LIBEVENT)/include
+LDFLAGS=-static -g -L$(LIBEVENT)/.libs
+LDFLAGS=-g -L$(LIBEVENT)/.libs
+LIBS=-levent -levent_openssl -lssl
+
+
+all:	get443_4
+
+GET443_4_OBJ=get443.o connectbyname.o
+
+get443_4: $(GET443_4_OBJ)
+	$(CC) $(LDFLAGS) -o $@ $(GET443_4_OBJ) $(LIBS)
+
+clean:
+	rm -f get443_4 $(GET443_4_OBJ)

--- a/proto4/README
+++ b/proto4/README
@@ -1,0 +1,4 @@
+Prototype based on libevent, call evdns_base_resolve_ipv4 and
+evdns_base_resolve_ipv6, then connect using happy eyeballs to avoid waiting
+too long for a connect to fail. Create an SSL bufferevent and wait for the
+buffer to become writable.

--- a/proto4/connectbyname.c
+++ b/proto4/connectbyname.c
@@ -1,0 +1,1072 @@
+/*
+connectbyname.c
+
+Implementation of connectbyname
+*/
+
+#if 0
+#include <errno.h>
+#include <stdio.h>
+#include <time.h>
+#include <arpa/inet.h>
+#endif
+
+#include <assert.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <event2/event.h>
+#include <event2/dns.h>
+#include <event2/bufferevent_ssl.h>
+
+#include <openssl/ssl.h>
+
+#include "connectbyname.h"
+
+#define MAXADDRS	16
+#define TIMEOUT_NS	  25000000	/* 25 ms */
+#if 1
+#undef TIMEOUT_NS
+#define TIMEOUT_NS	5000000000	
+#endif
+#define US_PER_SEC	   1000000	/* Microseconds in a second */
+#define NS_PER_SEC	1000000000	/* Nanoseconds in a second */
+
+struct addrlist
+{
+	int timeout;
+	int error;
+	int socket;
+	int selected;
+	struct sockaddr_storage addr;
+	socklen_t addrlen;
+	struct timespec endtime;
+	struct event *event;
+	struct bufferevent *bev;
+};
+
+struct work_ctx
+{
+	unsigned port;			/* Port number to connect to */
+	cbn_callback_T user_cb;
+	void *user_ref;
+
+	unsigned state;
+	struct evdns_request *evdns_ipv4;
+	struct evdns_request *evdns_ipv6;
+	struct addrlist alist[MAXADDRS];
+	unsigned naddrs;
+	struct addrlist *mlist[MAXADDRS];
+
+	/* If IPv4 address arrive first, we wait a bit for the IPv6 addresses
+	 * to arrive. If the time expires, we start connecting to the IPv4
+	 * addresses.
+	 */
+	struct event *ipv6_to_event;
+	struct timespec ipv6_timeout;
+
+	/* Event for connect timeout */
+	struct event *connect_to_event;
+
+	SSL_CTX *tls_ctx;
+
+	struct cbn_context *base;
+};
+
+#define STATE_INITIAL			0
+#define STATE_DNS			1
+#define STATE_DNS_IPV4_CONNECTING	2
+#define STATE_DNS_IPV6_WAITING		3
+#define STATE_DNS_IPV6_CONNECTING	4
+#define STATE_CONNECTING		5
+
+static void dns_callback(int result, char type, int count, int ttl, 
+	void *addresses, void *arg);
+static void timeout_callback(evutil_socket_t fd, short events, void *ref);
+static void connect_callback(evutil_socket_t fd, short events, void *ref);
+static void connect_to_callback(evutil_socket_t fd, short events, void *ref);
+static void read_callback(struct bufferevent *bev, void *ref);
+static void write_callback(struct bufferevent *bev, void *ref);
+static void event_callback(struct bufferevent *bev, short what, void *ref);
+static void merge_v4_v6(struct work_ctx *ctxp);
+static void do_connect(struct work_ctx *ctxp);
+static void ts_add_ns(struct timespec *tsp, long ns);
+static void ts_sub(struct timespec *res,
+	struct timespec *v1, struct timespec *v2);
+static void tv_from_ts(struct timeval *tv, struct timespec *ts);
+
+int cbn_init(struct cbn_context *cbn_ctx, struct event_base *event_base)
+{
+	memset(cbn_ctx, '\0', sizeof(*cbn_ctx));
+	cbn_ctx->event_base= event_base;
+	return 0;
+}
+
+void cbn_clean(struct cbn_context *cbn_ctx)
+{
+	evdns_base_free(cbn_ctx->evdns_base, 0);
+	cbn_ctx->evdns_base= NULL;
+	cbn_ctx->event_base= NULL;
+}
+
+int connectbyname_asyn(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname,
+	cbn_callback_T user_cb, void *user_ref, void **refp)
+{
+	int flags;
+	unsigned long port_ul;
+	char *next;
+	struct servent *se;
+	struct work_ctx *work_ctx;
+
+	/* Parse servname */
+	port_ul= strtoul(servname, &next, 10);
+	if (next[0] == '\0')
+	{
+		if (port_ul == 0 || port_ul >= 0x10000)
+		{
+			/* XXX should convert error */
+			return -1;
+		}
+		port_ul= htons(port_ul);
+	}
+	else
+	{
+		se= getservbyname(servname, "tcp");
+		if (se == NULL)
+			return -1;	/* XXX convert error */
+		port_ul= se->s_port;
+	}
+
+	assert(cbn_ctx->event_base);
+	if (!cbn_ctx->evdns_base)
+	{
+		cbn_ctx->evdns_base= evdns_base_new(cbn_ctx->event_base, EVDNS_BASE_INITIALIZE_NAMESERVERS);
+
+		/* Should check for failure */
+	}
+
+	work_ctx= malloc(sizeof(*work_ctx));
+	memset(work_ctx, '\0', sizeof(*work_ctx));
+	work_ctx->base= cbn_ctx;
+	work_ctx->port= port_ul;
+	work_ctx->user_cb= user_cb;
+	work_ctx->user_ref= user_ref;
+
+	work_ctx->state= STATE_INITIAL;
+
+	work_ctx->state= STATE_DNS;
+
+	flags= 0;
+	work_ctx->evdns_ipv4= evdns_base_resolve_ipv4(cbn_ctx->evdns_base,
+		hostname, flags, dns_callback, work_ctx);
+	work_ctx->evdns_ipv6= evdns_base_resolve_ipv6(cbn_ctx->evdns_base,
+		hostname, flags, dns_callback, work_ctx);
+
+	*refp= work_ctx;
+	return 0;
+
+#if 0
+	int i, j, r, s, any, best, done, do_timeout, error, maxfd, 
+		naddrs, prefer_ipv6, saved_r, sock;
+	socklen_t socklen;
+	long nsecdiff;
+	struct addrinfo *res, *tres;
+	struct addrinfo *reslist[MAXADDRS];
+	struct addrlist *ap;
+	struct addrinfo hints;
+	char addrstr[INET6_ADDRSTRLEN];
+	fd_set wrset, errset;
+	struct timeval timeout;
+	struct timespec now;
+
+	memset(&hints, '\0', sizeof(hints));
+	hints.ai_socktype= SOCK_STREAM;
+
+	r= getaddrinfo(hostname, servname, &hints, &res);
+	if (r != 0)
+		return -1;	/* XXX convert error */
+
+	/* Copy res entries to reslist */
+	for (naddrs= 0, tres= res; naddrs < MAXADDRS, tres;
+		naddrs++, tres= tres->ai_next)
+	{
+		reslist[naddrs]= tres;
+	}
+
+	printf("before sorting:\n");
+	for (i= 0; i<naddrs; i++)
+	{
+		getnameinfo(reslist[i]->ai_addr, reslist[i]->ai_addrlen, 
+			addrstr, sizeof(addrstr), NULL, 0, NI_NUMERICHOST);
+		printf("%s\n", addrstr);
+	}
+
+	/* Try to interleave IPv4 and IPv6 addresses */
+	prefer_ipv6= 1;
+	for (i= 0; i<naddrs; i++)
+	{
+		alist[i].error= 0;
+		alist[i].socket= -1;
+
+		best= -1;
+		any= -1;
+		for (j= 0; j<naddrs; j++)
+		{
+			tres= reslist[j];
+			if (!tres)
+				continue;
+			if (any == -1)
+				any= j;
+			if (prefer_ipv6)
+			{
+				if (tres->ai_family == AF_INET6)
+				{
+					best= j;
+					prefer_ipv6= 0;	/* IPv4 next time */
+					break;
+				}
+			}
+			else
+			{
+				if (tres->ai_family == AF_INET)
+				{
+					best= j;
+					prefer_ipv6= 1;	/* IPv6 next time */
+					break;
+				}
+			}
+		}
+		if (best != -1)
+		{
+			alist[i].ai= reslist[best];
+			reslist[best]= NULL;
+			continue;
+		}
+		assert(any != -1);
+		alist[i].ai= reslist[any];
+		reslist[any]= NULL;
+	}
+
+	printf("after sorting:\n");
+	for (i= 0; i<naddrs; i++)
+	{
+		getnameinfo(alist[i].ai->ai_addr, alist[i].ai->ai_addrlen, 
+			addrstr, sizeof(addrstr), NULL, 0, NI_NUMERICHOST);
+		printf("%s\n", addrstr);
+	}
+
+	for(;;)
+	{
+		done= 1;	/* Assume we are done. Will be cleared when
+				 * there is work to do.
+				 */
+		FD_ZERO(&wrset);
+		FD_ZERO(&errset);
+		maxfd= 0;
+		do_timeout= 0;
+		clock_gettime(CLOCK_MONOTONIC, &now);
+		for (i= 0, ap= alist; i<naddrs; i++, ap++)
+		{
+			fprintf(stderr, "%d: error %d\n", i, ap->error);
+			if (ap->error)
+			{
+				continue;	/* This address already
+						 * failed.
+						 */
+			}
+			fprintf(stderr, "%d: socket %d\n", i, ap->socket);
+
+			if (ap->socket == -1)
+			{
+				r= socket(ap->ai->ai_family,
+					ap->ai->ai_socktype, 
+					ap->ai->ai_protocol);
+				if (r == -1)
+				{
+					ap->error= errno;
+					continue;
+				}
+
+				ap->socket= r;
+
+				/* Switch to nonblocking */
+				fcntl(ap->socket, F_SETFL,
+					fcntl(ap->socket, F_GETFL) |
+					O_NONBLOCK);
+
+				r= connect(ap->socket, ap->ai->ai_addr,
+					ap->ai->ai_addrlen);
+				if (r == 0)
+				{
+					/* This is weird, a nonblocking
+					 * connect that succeeds. In any,
+					 * we got what we wanted.
+					 */
+					done= 1; /* signal that we are done */
+					break;
+				}
+				else if (errno == EINPROGRESS)
+				{
+					/* This is what we expect, fall
+					 * through.
+					 */
+				}
+				else
+				{
+					/* Some kind of error */
+					ap->error= errno;
+					continue;
+				}
+
+				ap->timeout= 0;
+				ap->endtime.tv_sec= now.tv_sec + 
+					TIMEOUT_NS / NS_PER_SEC;
+				ap->endtime.tv_nsec= now.tv_nsec +
+					TIMEOUT_NS % NS_PER_SEC;
+				if (ap->endtime.tv_nsec >= NS_PER_SEC)
+				{
+					ap->endtime.tv_nsec -= NS_PER_SEC;
+					ap->endtime.tv_sec++;
+				}
+			}
+
+			assert(ap->socket != -1 && ap->error == 0);
+			FD_SET(ap->socket, &wrset);
+			FD_SET(ap->socket, &errset);
+			if (ap->socket > maxfd)
+				maxfd= ap->socket;
+			done= 0;
+
+			if (!ap->timeout)
+			{
+				if (ap->endtime.tv_sec < now.tv_sec ||
+					(ap->endtime.tv_sec == now.tv_sec &&
+					ap->endtime.tv_nsec <= now.tv_nsec))
+				{
+					/* We got a timeout, move to the
+					 * next address.
+					 */
+					ap->timeout= 1;
+					continue;
+				}
+
+				timeout.tv_sec= ap->endtime.tv_sec-now.tv_sec;
+				nsecdiff= ap->endtime.tv_nsec-now.tv_nsec;
+				if (nsecdiff < 0)
+				{
+					nsecdiff += NS_PER_SEC;
+					timeout.tv_sec--;
+				}
+				timeout.tv_usec= nsecdiff/1000+1;
+				do_timeout= 1;
+				break;
+			}
+		}
+
+		if (done)
+		{
+			if (i < naddrs)
+				break;	/* Got something */
+
+			/* All addresses failed. */
+			assert(alist[0].error);
+			break;
+		}
+
+		r= select(maxfd+1, NULL, &wrset, &errset,
+			do_timeout ? &timeout : NULL);
+		fprintf(stderr, "select returned %d\n", r);
+
+		if (r > 0)
+		{
+			/* Just look at all sockets */
+			for (i= 0, ap= alist; i<naddrs; i++, ap++)
+			{
+				if (ap->error)
+					continue;
+				sock= ap->socket;
+				if (sock == -1)
+					continue;
+				if (FD_ISSET(sock, &wrset))
+				{
+					/* Check for error */
+					socklen= sizeof(error);
+					r= getsockopt(sock, SOL_SOCKET,
+						SO_ERROR, &error, &socklen);
+					if (r == -1)
+					{
+						/* Weird */
+						ap->error= errno;
+						continue;
+					}
+					if (error)
+					{
+						ap->error= error;
+						continue;
+					}
+
+					/* No error, got one */
+					break;
+
+				}
+				if (FD_ISSET(sock, &errset))
+				{
+					/* What do we now? */
+					fprintf(stderr, "what about errset?\n");
+					abort();
+				}
+			}
+
+			if (i<naddrs)
+				break;
+		}
+
+		/* Try again */
+	}
+
+	freeaddrinfo(res);
+	sock= -1;
+	if (i < naddrs)
+	{
+		sock= alist[i].socket;
+		alist[i].socket= -1;
+	}
+	for (i= 0, ap= alist; i<naddrs; i++, ap++)
+	{
+		if (ap->socket != -1)
+		{
+			close(ap->socket);
+			ap->socket= -1;
+		}
+	}
+	if (sock != -1)
+	{
+		/* Switch socket back to blocking */
+		fcntl(sock, F_SETFL, fcntl(sock, F_GETFL) & ~O_NONBLOCK);
+		*fdp= sock;
+		return 0;	/* Success */
+	}
+
+	/* Should convert error to result value */
+	return -1;
+#endif
+}
+
+void connectbyname_free(void *ref)
+{
+	struct work_ctx *ctxp;
+
+	ctxp= ref;
+
+	/* We should check what needs to be freed or canceled */
+
+	free(ctxp);
+	ctxp= NULL;
+}
+
+static void dns_callback(int result, char type, int count, int ttl, 
+	void *addresses, void *arg)
+{
+	int i;
+	struct work_ctx *ctxp;
+	struct sockaddr_in *sin4p;
+	struct sockaddr_in6 *sin6p;
+	struct addrlist *alist;
+	uint8_t (*addrs4)[4];
+	uint8_t (*addrs6)[16];
+	struct timespec timeout;
+	char addrstr[INET6_ADDRSTRLEN];
+
+	ctxp= arg;
+	if (result != DNS_ERR_NONE)
+	{
+		/* Should handle DNS errors */
+		fprintf(stderr, "dns_callback, result %d\n", result);
+		return;
+	}
+	switch(type)
+	{
+	case DNS_IPv4_A:
+		addrs4= addresses;
+		for (i= 0, alist= &ctxp->alist[ctxp->naddrs]; i<count;
+			i++, alist++)
+		{
+			if (ctxp->naddrs >= MAXADDRS)
+				break;
+
+			alist->error= 0;
+			alist->socket= -1;
+
+			sin4p= (struct sockaddr_in *)&alist->addr;
+			memset(sin4p, '\0', sizeof(*sin4p));
+			sin4p->sin_family= AF_INET;
+			memcpy(&sin4p->sin_addr, addrs4[i],
+				sizeof(sin4p->sin_addr));
+			sin4p->sin_port= ctxp->port;
+			alist->addrlen= sizeof(*sin4p);
+			ctxp->naddrs++;
+		}
+
+		merge_v4_v6(ctxp);
+
+		switch(ctxp->state)
+		{
+		case STATE_DNS:
+			ctxp->state= STATE_DNS_IPV6_WAITING;
+			ctxp->ipv6_to_event= evtimer_new(ctxp->base->event_base,
+				timeout_callback, ctxp);
+			clock_gettime(CLOCK_MONOTONIC, &timeout);
+			fprintf(stderr, "dns_callback: now %d.%09d\n",
+				timeout.tv_sec, timeout.tv_nsec);
+			timeout.tv_nsec += TIMEOUT_NS % NS_PER_SEC;
+			timeout.tv_sec += TIMEOUT_NS / NS_PER_SEC;
+			fprintf(stderr, "dns_callback: timeout %d.%09d\n",
+				timeout.tv_sec, timeout.tv_nsec);
+			if (timeout.tv_nsec >= NS_PER_SEC)
+			{
+				timeout.tv_nsec -= NS_PER_SEC;
+				timeout.tv_sec++;
+			}
+			fprintf(stderr, "dns_callback: timeout %d.%09d\n",
+				timeout.tv_sec, timeout.tv_nsec);
+			ctxp->ipv6_timeout= timeout;
+
+			/* The timeout callback will set the timer. */
+			timeout_callback(-1, 0, ctxp);
+			break;
+
+		case STATE_DNS_IPV4_CONNECTING:
+			ctxp->state= STATE_CONNECTING;
+
+			fprintf(stderr,
+			"dns_callback: before do_connect, addresses:\n");
+			for (i= 0; i<ctxp->naddrs; i++)
+			{
+				getnameinfo((struct sockaddr *)
+					&ctxp->mlist[i]->addr,
+					ctxp->mlist[i]->addrlen, 
+					addrstr, sizeof(addrstr), NULL, 0,
+					NI_NUMERICHOST);
+				fprintf(stderr, "%s\n", addrstr);
+			}
+			do_connect(ctxp);
+			break;
+
+		default:
+			fprintf(stderr,
+				"dns_callback: unknown state %d (IPv4)\n",
+				ctxp->state);
+			return;
+		}
+
+		break;
+
+	case DNS_IPv6_AAAA:
+		addrs6= addresses;
+		for (i= 0, alist= &ctxp->alist[ctxp->naddrs]; i<count;
+			i++, alist++)
+		{
+			if (ctxp->naddrs >= MAXADDRS)
+				break;
+
+			alist->error= 0;
+			alist->socket= -1;
+
+			sin6p= (struct sockaddr_in6 *)&alist->addr;
+			memset(sin6p, '\0', sizeof(*sin6p));
+			sin6p->sin6_family= AF_INET6;
+			memcpy(&sin6p->sin6_addr, addrs6[i],
+				sizeof(sin6p->sin6_addr));
+			sin6p->sin6_port= ctxp->port;
+			alist->addrlen= sizeof(*sin6p);
+			ctxp->naddrs++;
+		}
+
+		merge_v4_v6(ctxp);
+
+		switch(ctxp->state)
+		{
+		case STATE_DNS:
+			ctxp->state= STATE_DNS_IPV4_CONNECTING;
+			fprintf(stderr,
+			"dns_callback: before do_connect, addresses:\n");
+			for (i= 0; i<ctxp->naddrs; i++)
+			{
+				getnameinfo((struct sockaddr *)
+					&ctxp->mlist[i]->addr,
+					ctxp->mlist[i]->addrlen, 
+					addrstr, sizeof(addrstr), NULL, 0,
+					NI_NUMERICHOST);
+				fprintf(stderr, "%s\n", addrstr);
+			}
+			do_connect(ctxp);
+			break;
+
+		case STATE_DNS_IPV6_WAITING:
+			/* Cancel timer */
+			evtimer_del(ctxp->ipv6_to_event);
+			event_free(ctxp->ipv6_to_event);
+			ctxp->ipv6_to_event= NULL;
+			ctxp->state= STATE_CONNECTING;
+			fprintf(stderr,
+			"dns_callback: before do_connect, addresses:\n");
+			for (i= 0; i<ctxp->naddrs; i++)
+			{
+				getnameinfo((struct sockaddr *)
+					&ctxp->mlist[i]->addr,
+					ctxp->mlist[i]->addrlen, 
+					addrstr, sizeof(addrstr), NULL, 0,
+					NI_NUMERICHOST);
+				fprintf(stderr, "%s\n", addrstr);
+			}
+			do_connect(ctxp);
+			break;
+			
+		default:
+			fprintf(stderr,
+			"dns_callback: unknown state %d (IPv6)\n",
+				ctxp->state);
+			return;
+		}
+
+		break;
+
+	default:
+		fprintf(stderr, "dns_callback; unknown type %d\n", type);
+		return;
+	}
+}
+
+static void timeout_callback(evutil_socket_t fd, short events, void *ref)
+{
+	struct work_ctx *ctxp;
+	struct timespec now;
+	struct timeval timeout;
+
+	ctxp= ref;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	fprintf(stderr, "timeout_callback: now %d.%09d\n",
+		now.tv_sec, now.tv_nsec);
+	fprintf(stderr, "timeout_callback: target %d.%09d\n",
+		ctxp->ipv6_timeout.tv_sec, ctxp->ipv6_timeout.tv_nsec);
+
+	if (now.tv_sec < ctxp->ipv6_timeout.tv_sec ||
+		(now.tv_sec == ctxp->ipv6_timeout.tv_sec &&
+		now.tv_nsec < ctxp->ipv6_timeout.tv_nsec))
+	{
+		/* Set timer */
+		timeout.tv_sec= ctxp->ipv6_timeout.tv_sec - now.tv_sec;
+		timeout.tv_usec= (ctxp->ipv6_timeout.tv_nsec - now.tv_nsec)/
+			1000 + 1;
+
+		fprintf(stderr, "timeout %d.%06d\n",
+			timeout.tv_sec, timeout.tv_usec);
+		if (timeout.tv_usec < 0)
+		{
+			timeout.tv_usec += US_PER_SEC;
+			timeout.tv_sec--;
+		}
+		fprintf(stderr, "timeout %d.%06d\n",
+			timeout.tv_sec, timeout.tv_usec);
+		evtimer_add(ctxp->ipv6_to_event, &timeout);
+		return;
+	}
+
+	/* The state should be STATE_DNS_IPV6_WAITING. Ignore other states */
+	if (ctxp->state != STATE_DNS_IPV6_WAITING)
+	{
+		fprintf(stderr, "timeout_callback: bad state %d\n",
+			ctxp->state);
+		return;
+	}
+
+	/* Start connecting */
+	ctxp->state= STATE_DNS_IPV6_CONNECTING;
+	do_connect(ctxp);
+}
+
+static void connect_callback(evutil_socket_t fd, short events, void *ref)
+{
+	int i, r, error, sock;
+	socklen_t socklen;
+	struct work_ctx *ctxp;
+	struct addrlist *ap;
+	void (*user_cb)(int fd, void *ref);
+	void *user_ref;
+	SSL *tls;
+
+	ctxp= ref;
+
+	/* Just look at all sockets */
+	for (i= 0, ap= ctxp->alist; i<ctxp->naddrs; i++, ap++)
+	{
+		if (ap->socket == fd)
+			break;
+	}
+
+	if (i >= ctxp->naddrs)
+	{
+		/* Weird. */
+		fprintf(stderr, "connect_callback: socket not found\n");
+		return;
+
+	}
+
+	/* Check for error */
+	socklen= sizeof(error);
+	r= getsockopt(fd, SOL_SOCKET, SO_ERROR, &error, &socklen);
+	if (r == -1)
+	{
+		/* Weird */
+		ap->error= errno;
+		do_connect(ctxp);
+		return;
+	}
+	if (error)
+	{
+		ap->error= error;
+		do_connect(ctxp);
+		return;
+	}
+
+	sock= ap->socket;
+
+	assert(ap->event);
+	event_del(ap->event);
+	event_free(ap->event);
+	ap->event= NULL;
+
+	fprintf(stderr,  "connect_callback: starting SSL for fd %d\n", sock);
+
+	if (!ctxp->tls_ctx)
+	{
+		ctxp->tls_ctx= SSL_CTX_new(TLS_method());
+	}
+
+	tls= SSL_new(ctxp->tls_ctx);
+
+	assert(!ap->bev);
+	ap->bev= bufferevent_openssl_socket_new(ctxp->base->event_base,
+		sock, tls, BUFFEREVENT_SSL_CONNECTING, BEV_OPT_CLOSE_ON_FREE);
+
+	bufferevent_setcb(ap->bev, read_callback, write_callback, 
+		event_callback, ctxp);
+
+
+#if 0
+	for (i= 0, ap= ctxp->alist; i<ctxp->naddrs; i++, ap++)
+	{
+		if (ap->socket == -1)
+			continue;
+
+	}
+
+	/* Should deal with 
+	struct evdns_request *evdns_ipv4;
+	struct evdns_request *evdns_ipv6;
+	*/
+
+	user_cb= ctxp->user_cb;
+	user_ref= ctxp->user_ref;
+
+	/* Should free ctxp */
+
+	(*user_cb)(sock, user_ref);
+#endif
+}
+
+static void connect_to_callback(evutil_socket_t fd, short events, void *ref)
+{
+	struct work_ctx *ctxp;
+
+	ctxp= ref;
+
+	fprintf(stderr, "connect_to_callback: restarting connect\n");
+	do_connect(ctxp);
+}
+
+static void read_callback(struct bufferevent *bev, void *ctx)
+{
+	fprintf(stderr, "in read_callback\n");
+}
+
+static void write_callback(struct bufferevent *bev, void *ctx)
+{
+	fprintf(stderr, "in write_callback\n");
+}
+
+static void event_callback(struct bufferevent *bev, short what, void *ref)
+{
+	int i;
+	struct work_ctx *ctxp;
+	struct addrlist *ap;
+	struct bufferevent *lbev;
+
+	ctxp= ref;
+
+	fprintf(stderr, "in event_callback, what 0x%x\n", what);
+
+	if (what != BEV_EVENT_CONNECTED)
+	{
+		fprintf(stderr,
+			"event_callback, TLS connect failed with 0x%x\n",
+			what);
+		
+	}
+
+	/* Kill timers */
+	if (ctxp->ipv6_to_event)
+	{
+		evtimer_del(ctxp->ipv6_to_event);
+		event_free(ctxp->ipv6_to_event);
+		ctxp->ipv6_to_event= NULL;
+	}
+
+	assert(ctxp->connect_to_event);
+	evtimer_del(ctxp->connect_to_event);
+	event_free(ctxp->connect_to_event);
+	ctxp->connect_to_event= NULL;
+
+	/* Find bev */
+	for (i= 0, ap= ctxp->alist; i<ctxp->naddrs; i++, ap++)
+	{
+		if (ap->bev == bev)
+		{
+			/* Found the right event */
+			ap->bev= NULL;
+			ap->socket= -1;
+			continue;
+		}
+		if (!ap->bev)
+		{
+			if (ap->socket != -1)
+			{
+				assert(ap->event);
+				event_del(ap->event);
+				event_free(ap->event);
+				ap->event= NULL;
+
+				close(ap->socket);
+				ap->socket= -1;
+			}
+			continue;
+		}
+
+		lbev= ap->bev;
+		ap->bev= NULL;
+		bufferevent_free(lbev);
+		lbev= NULL;
+	}
+
+	ctxp->user_cb(bev, ctxp->user_ref);
+}
+
+static void merge_v4_v6(struct work_ctx *ctxp)
+{
+	int i, j, any, best, prefer_ipv6;
+	struct addrlist *ap;
+
+	for (i= 0, ap= ctxp->alist; i<ctxp->naddrs; i++, ap++)
+		ap->selected= 0;
+
+	/* Try to interleave IPv4 and IPv6 addresses */
+	prefer_ipv6= 1;
+	for (i= 0; i<ctxp->naddrs; i++)
+	{
+		best= -1;
+		any= -1;
+		for (j= 0, ap= ctxp->alist; j<ctxp->naddrs; j++, ap++)
+		{
+			if (ap->selected)
+				continue;
+
+			if (any == -1)
+				any= j;
+			if (prefer_ipv6)
+			{
+				if (ap->addr.ss_family == AF_INET6)
+				{
+					best= j;
+					prefer_ipv6= 0;	/* IPv4 next time */
+					break;
+				}
+			}
+			else
+			{
+				if (ap->addr.ss_family == AF_INET)
+				{
+					best= j;
+					prefer_ipv6= 1;	/* IPv6 next time */
+					break;
+				}
+			}
+		}
+		if (best != -1)
+		{
+			ctxp->mlist[i]= &ctxp->alist[best];
+			ctxp->alist[best].selected= 1;
+			continue;
+		}
+		assert(any != -1);
+		ctxp->mlist[i]= &ctxp->alist[any];
+		ctxp->alist[any].selected= 1;
+	}
+}
+
+static void do_connect(struct work_ctx *ctxp)
+{
+	int i, r, done, do_timeout;
+	struct addrlist *ap;
+	struct timespec now, timeout_ns;
+	struct timeval timeout;
+
+	done= 1;	/* Assume we are done. Will be cleared when
+			 * there is work to do.
+			 */
+	do_timeout= 0;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	for (i= 0; i<ctxp->naddrs; i++)
+	{
+		ap= ctxp->mlist[i];
+
+		if (ap->error)
+		{
+			continue;	/* This address already
+					 * failed.
+					 */
+		}
+
+		if (ap->socket == -1)
+		{
+			r= socket(ap->addr.ss_family, SOCK_STREAM, 0);
+			if (r == -1)
+			{
+				ap->error= errno;
+				continue;
+			}
+
+			ap->socket= r;
+
+			/* Switch to nonblocking */
+			fcntl(ap->socket, F_SETFL,
+				fcntl(ap->socket, F_GETFL) |
+				O_NONBLOCK);
+
+			r= connect(ap->socket, (struct sockaddr *)&ap->addr,
+				ap->addrlen);
+			if (r == 0)
+			{
+				/* This is weird, a nonblocking
+				 * connect that succeeds. In any case,
+				 * we got what we wanted.
+				 */
+				done= 1; /* signal that we are done */
+				break;
+			}
+			else if (errno == EINPROGRESS)
+			{
+				/* This is what we expect, fall
+				 * through.
+				 */
+			}
+			else
+			{
+				/* Some kind of error */
+				ap->error= errno;
+				continue;
+			}
+
+			ap->timeout= 0;
+			ap->endtime= now;
+			ts_add_ns(&ap->endtime, TIMEOUT_NS);
+
+			assert(!ap->event);
+			ap->event= event_new(ctxp->base->event_base,
+				ap->socket, EV_WRITE, connect_callback, ctxp);
+			event_add(ap->event, NULL);
+		}
+
+		assert(ap->socket != -1 && ap->error == 0);
+		done= 0;
+
+		if (!ap->timeout)
+		{
+			if (ap->endtime.tv_sec < now.tv_sec ||
+				(ap->endtime.tv_sec == now.tv_sec &&
+				ap->endtime.tv_nsec <= now.tv_nsec))
+			{
+				/* We got a timeout, move to the
+				 * next address.
+				 */
+				ap->timeout= 1;
+				continue;
+			}
+
+			ts_sub(&timeout_ns, &ap->endtime, &now);
+			tv_from_ts(&timeout, &timeout_ns);
+			do_timeout= 1;
+			break;
+		}
+	}
+
+	if (done)
+	{
+		if (i < ctxp->naddrs)
+		{
+			fprintf(stderr, "do_connect: found one\n");
+			return;	/* Got something */
+		}
+
+		/* All addresses failed. */
+		fprintf(stderr, "do_connect: all failed\n");
+		assert(ctxp->alist[0].error);
+		return;
+	}
+
+	if (do_timeout)
+	{
+		if (!ctxp->connect_to_event)
+		{
+			ctxp->connect_to_event=
+				evtimer_new(ctxp->base->event_base,
+				connect_to_callback, ctxp);
+		}
+		evtimer_add(ctxp->connect_to_event, &timeout);
+	}
+
+}
+
+static void ts_add_ns(struct timespec *tsp, long ns)
+{
+	tsp->tv_sec += TIMEOUT_NS / NS_PER_SEC;
+	tsp->tv_nsec += TIMEOUT_NS % NS_PER_SEC;
+	if (tsp->tv_nsec >= NS_PER_SEC)
+	{
+		tsp->tv_nsec -= NS_PER_SEC;
+		tsp->tv_sec++;
+	}
+}
+
+static void ts_sub(struct timespec *res,
+	struct timespec *v1, struct timespec *v2)
+{
+	res->tv_sec= v1->tv_sec-v2->tv_sec;
+	res->tv_nsec= v1->tv_nsec-v2->tv_nsec;
+	if (res->tv_nsec < 0)
+	{
+		res->tv_nsec += NS_PER_SEC;
+		res->tv_sec--;
+	}
+}
+
+static void tv_from_ts(struct timeval *tv, struct timespec *ts)
+{
+	tv->tv_sec= ts->tv_sec;
+	tv->tv_usec= ts->tv_nsec/1000;
+	if (ts->tv_nsec % 1000)
+		tv->tv_usec++;	/* Round up */
+}

--- a/proto4/connectbyname.h
+++ b/proto4/connectbyname.h
@@ -1,0 +1,26 @@
+/*
+connectbyname.h
+
+Interface for connectbyname
+*/
+
+struct cbn_context
+{
+	struct event_base *event_base;
+	struct evdns_base *evdns_base;
+};
+
+struct bufferevent;
+typedef void (*cbn_callback_T)(struct bufferevent *bev, void *ref);
+
+int cbn_init(struct cbn_context *cbn_ctx, struct event_base *event_base);
+void cbn_clean(struct cbn_context *cbn_ctx);
+
+int connectbyname(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname, int *fdp);
+
+int connectbyname_asyn(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname,
+	cbn_callback_T user_cb, void *user_ref, void **refp);
+
+void connectbyname_free(void *ref);

--- a/proto4/get443.c
+++ b/proto4/get443.c
@@ -1,0 +1,164 @@
+/*
+get443.c
+
+Send a HTTP GET request to a target and print the result.
+*/
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+
+#include <event2/event.h>
+#include <event2/bufferevent.h>
+
+#include "connectbyname.h"
+
+struct state
+{
+	char *hostname;
+	struct event_base *event_base;
+	struct event *event;
+	void *cbn_ref;
+
+	struct cbn_context cbn_ctx;
+};
+
+static void callback(struct bufferevent *bev, void *ref);
+static void read_callback(struct bufferevent *bev, void *ref);
+static void event_callback(struct bufferevent *bev, short what, void *ref);
+static void usage(void);
+
+int main(int argc, char *argv[])
+{
+	int r, s;
+	FILE *f;
+	char *hostname;
+	void *ref;
+	struct event_base *event_base;
+	char buf[1024];
+	struct state state;
+
+	if (argc != 2)
+		usage();
+
+	hostname= argv[1];
+	state.hostname= hostname;
+
+	event_enable_debug_mode();
+	event_base= event_base_new();
+	state.event_base= event_base;
+	cbn_init(&state.cbn_ctx, event_base);
+	r= connectbyname_asyn(&state.cbn_ctx, hostname, "https",
+		callback, &state, &ref);
+	if (r)
+	{
+		fprintf(stderr, "connectbyname failed: %d\n", r);
+		exit(1);
+	}
+	state.cbn_ref= ref;
+
+	r= event_base_dispatch(event_base);
+	fprintf(stderr, "event_base_dispatch returned: %d\n", r);
+	abort();
+
+	f= fdopen(s, "r+");
+	if (f == NULL)
+	{
+		fprintf(stderr, "fdopen failed: %s\n", strerror(errno));
+		exit(1);
+	}
+	fprintf(f, "GET / HTTP/1.1\r\nHost: %s\r\n\r\n", hostname);
+	fflush(f);
+	shutdown(s, SHUT_WR);
+	for(;;)
+	{
+		r= fread(buf, 1, sizeof(buf), f);
+		if (r == 0)
+		{
+			if (feof(f))
+				break;
+			fprintf(stderr, "read error: %s\n", strerror(errno));
+			exit(1);
+		}
+		fwrite(buf, r, 1, stdout);
+	}
+	fclose(f);
+	exit(0);
+}
+
+static void callback(struct bufferevent *bev, void *ref)
+{
+	struct state *statep;
+	char reqline[80];
+
+	statep= ref;
+
+	snprintf(reqline, sizeof(reqline),
+		"GET / HTTP/1.1\r\nHost: %s\r\n\r\n", statep->hostname);
+	
+	/* Assume write will not block */
+	bufferevent_write(bev, reqline, strlen(reqline));
+	bufferevent_enable(bev, EV_READ);
+	bufferevent_setcb(bev, read_callback, NULL, event_callback, ref);
+}
+
+static void read_callback(struct bufferevent *bev, void *ref)
+{
+	int r;
+	char line[1024];
+
+	printf("\n\nin read_callback\n\n");
+
+	for (;;)
+	{
+		r= bufferevent_read(bev, line, sizeof(line));
+		if (r == 0)
+			break;
+		if (r == -1)
+		{
+			fprintf(stderr, "read error %s\n", strerror(errno));
+			exit(1);
+		}
+		printf("%.*s", r, line);
+	}
+}
+
+static void event_callback(struct bufferevent *bev, short what, void *ref)
+{
+	struct state *statep;
+
+	statep= ref;
+
+	if ((what & (BEV_EVENT_READING|BEV_EVENT_EOF)) ==
+		(BEV_EVENT_READING|BEV_EVENT_EOF))
+	{
+		/* EOF */
+
+		/* Free bufferevent */
+		bufferevent_free(bev);
+		bev= NULL;
+		
+		/* Connectbyname call */
+		connectbyname_free(statep->cbn_ref);
+		statep->cbn_ref= NULL;
+
+		/* Connectbyname context */
+		cbn_clean(&statep->cbn_ctx);
+
+		/* event base */
+		event_base_free(statep->event_base);
+		statep->event_base= NULL;
+
+		exit(0);
+	}
+	fprintf(stderr, "event_callback: what %d\n", what);
+}
+
+static void usage(void)
+{
+	fprintf(stderr, "get80 <hostname>\n");
+	exit(1);
+}

--- a/proto5/Makefile
+++ b/proto5/Makefile
@@ -1,0 +1,17 @@
+LIBEVENT=/home/philip/src/libevent-2.1.11-stable
+
+CFLAGS=-g -I$(LIBEVENT)/include
+LDFLAGS=-static -g -L$(LIBEVENT)/.libs
+LDFLAGS=-g -L$(LIBEVENT)/.libs
+LIBS=-levent -levent_openssl -lssl /usr/lib/x86_64-linux-gnu/libgetdns_ex_event.a -L /home/philip/src/getdns-1.7.0 -Wl,-rpath=/home/philip/src/getdns-1.7.0 -lgetdns
+
+
+all:	get443_5
+
+GET443_5_OBJ=get443.o connectbyname.o
+
+get443_5: $(GET443_5_OBJ)
+	$(CC) $(LDFLAGS) -o $@ $(GET443_5_OBJ) $(LIBS)
+
+clean:
+	rm -f get443_5 $(GET443_5_OBJ)

--- a/proto5/README
+++ b/proto5/README
@@ -1,0 +1,3 @@
+Prototype based on libevent, use getdns for name resolution,
+then connect using happy eyeballs to avoid waiting too long for a connect to
+fail. Create an SSL bufferevent and wait for the buffer to become writable.

--- a/proto5/connectbyname.c
+++ b/proto5/connectbyname.c
@@ -1,0 +1,860 @@
+/*
+connectbyname.c
+
+Implementation of connectbyname
+*/
+
+#include <assert.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <event2/event.h>
+#include <event2/dns.h>
+#include <event2/bufferevent_ssl.h>
+
+#include <openssl/ssl.h>
+
+#include <getdns/getdns_ext_libevent.h>
+
+#include "connectbyname.h"
+
+#define MAXADDRS	16
+#define TIMEOUT_NS	  25000000	/* 25 ms */
+#if 1
+#undef TIMEOUT_NS
+#define TIMEOUT_NS	5000000000	
+#endif
+#define US_PER_SEC	   1000000	/* Microseconds in a second */
+#define NS_PER_SEC	1000000000	/* Nanoseconds in a second */
+
+struct addrlist
+{
+	int timeout;
+	int error;
+	int socket;
+	int selected;
+	struct sockaddr_storage addr;
+	socklen_t addrlen;
+	struct timespec endtime;
+	struct event *event;
+	struct bufferevent *bev;
+};
+
+struct work_ctx
+{
+	unsigned port;			/* Port number to connect to */
+	cbn_callback_T user_cb;
+	void *user_ref;
+
+	unsigned state;
+	getdns_transaction_t trans_id_ipv4;
+	getdns_transaction_t trans_id_ipv6;
+	struct addrlist alist[MAXADDRS];
+	unsigned naddrs;
+	struct addrlist *mlist[MAXADDRS];
+
+	/* If IPv4 address arrive first, we wait a bit for the IPv6 addresses
+	 * to arrive. If the time expires, we start connecting to the IPv4
+	 * addresses.
+	 */
+	struct event *ipv6_to_event;
+	struct timespec ipv6_timeout;
+
+	/* Event for connect timeout */
+	struct event *connect_to_event;
+
+	SSL_CTX *tls_ctx;
+
+	struct cbn_context *base;
+};
+
+#define STATE_INITIAL			0
+#define STATE_DNS			1
+#define STATE_DNS_IPV4_CONNECTING	2
+#define STATE_DNS_IPV6_WAITING		3
+#define STATE_DNS_IPV6_CONNECTING	4
+#define STATE_CONNECTING		5
+
+static void dns_callback(getdns_context *context,
+	getdns_callback_type_t callback_type,
+	getdns_dict *response,
+	void *userarg,
+	getdns_transaction_t transaction_id);
+static void timeout_callback(evutil_socket_t fd, short events, void *ref);
+static void connect_callback(evutil_socket_t fd, short events, void *ref);
+static void connect_to_callback(evutil_socket_t fd, short events, void *ref);
+static void read_callback(struct bufferevent *bev, void *ref);
+static void write_callback(struct bufferevent *bev, void *ref);
+static void event_callback(struct bufferevent *bev, short what, void *ref);
+static void merge_v4_v6(struct work_ctx *ctxp);
+static void do_connect(struct work_ctx *ctxp);
+static void ts_add_ns(struct timespec *tsp, long ns);
+static void ts_sub(struct timespec *res,
+	struct timespec *v1, struct timespec *v2);
+static void tv_from_ts(struct timeval *tv, struct timespec *ts);
+
+int cbn_init(struct cbn_context *cbn_ctx, struct event_base *event_base)
+{
+	memset(cbn_ctx, '\0', sizeof(*cbn_ctx));
+	cbn_ctx->event_base= event_base;
+	return 0;
+}
+
+void cbn_clean(struct cbn_context *cbn_ctx)
+{
+	getdns_context_destroy(cbn_ctx->getdns_ctx);
+	cbn_ctx->getdns_ctx= NULL;
+	cbn_ctx->event_base= NULL;
+}
+
+int connectbyname_asyn(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname,
+	cbn_callback_T user_cb, void *user_ref, void **refp)
+{
+	int flags;
+	getdns_return_t gdns_r;
+	unsigned long port_ul;
+	char *next;
+	struct servent *se;
+	struct work_ctx *work_ctx;
+
+	/* Parse servname */
+	port_ul= strtoul(servname, &next, 10);
+	if (next[0] == '\0')
+	{
+		if (port_ul == 0 || port_ul >= 0x10000)
+		{
+			/* XXX should convert error */
+			return -1;
+		}
+		port_ul= htons(port_ul);
+	}
+	else
+	{
+		se= getservbyname(servname, "tcp");
+		if (se == NULL)
+			return -1;	/* XXX convert error */
+		port_ul= se->s_port;
+	}
+
+	assert(cbn_ctx->event_base);
+
+	gdns_r= getdns_context_create(&cbn_ctx->getdns_ctx, 1);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr, "getdns_context_create failed\n");
+		return -1;
+	}
+
+	gdns_r= getdns_extension_set_libevent_base(cbn_ctx->getdns_ctx,
+		cbn_ctx->event_base);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr, "getdns_context_create failed\n");
+		return -1;
+	}
+	
+	work_ctx= malloc(sizeof(*work_ctx));
+	fprintf(stderr, "connectbyname_asyn: work_ctx = %p\n", work_ctx);
+	memset(work_ctx, '\0', sizeof(*work_ctx));
+	work_ctx->base= cbn_ctx;
+	work_ctx->port= port_ul;
+	work_ctx->user_cb= user_cb;
+	work_ctx->user_ref= user_ref;
+
+	work_ctx->state= STATE_INITIAL;
+
+	work_ctx->state= STATE_DNS;
+	gdns_r= getdns_general(cbn_ctx->getdns_ctx,
+		hostname, GETDNS_RRTYPE_AAAA,
+		NULL, work_ctx, &work_ctx->trans_id_ipv6,
+		dns_callback);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr, "getdns_general failed\n");
+		return -1;
+	}
+	gdns_r= getdns_general(cbn_ctx->getdns_ctx,
+		hostname, GETDNS_RRTYPE_A,
+		NULL, work_ctx, &work_ctx->trans_id_ipv4,
+		dns_callback);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr, "getdns_general failed\n");
+		return -1;
+	}
+
+	*refp= work_ctx;
+	return 0;
+}
+
+void connectbyname_free(void *ref)
+{
+	struct work_ctx *ctxp;
+
+	ctxp= ref;
+	fprintf(stderr, "connectbyname_free: ctxp = %p\n", ctxp);
+
+	/* We should check what needs to be freed or canceled */
+
+	free(ctxp);
+	ctxp= NULL;
+}
+
+static void dns_callback(getdns_context *context,
+	getdns_callback_type_t callback_type,
+	getdns_dict *response,
+	void *userarg,
+	getdns_transaction_t transaction_id)
+{
+#if 0
+	uint8_t (*addrs4)[4];
+	uint8_t (*addrs6)[16];
+#endif
+	int i, got_ipv4, got_ipv6;
+	getdns_return_t gdns_r;
+	size_t len;
+	struct work_ctx *ctxp;
+	getdns_list *answer_list;
+	getdns_dict *addr_dict;
+	getdns_bindata *addr_type;
+	getdns_bindata *addr_data;
+	struct addrlist *alist;
+	struct sockaddr_in *sin4p;
+	struct sockaddr_in6 *sin6p;
+	struct timespec timeout;
+	char addrstr[INET6_ADDRSTRLEN];
+
+	ctxp= userarg;
+	if (callback_type != GETDNS_CALLBACK_COMPLETE)
+	{
+		/* Should handle DNS errors */
+		fprintf(stderr, "dns_callback, callback_type %d\n",
+			callback_type);
+		goto cleanup;
+	}
+
+#if 0
+	printf("dns_callback: got\n");
+	printf("%s\n", getdns_pretty_print_dict(response));
+#endif
+	
+	gdns_r= getdns_dict_get_list(response, "just_address_answers",
+		&answer_list);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr,
+		"dns_callback: nothing for 'just_address_answers': %d\n",
+			gdns_r);
+		goto cleanup;
+	}
+	gdns_r= getdns_list_get_length(answer_list, &len);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr,
+		"dns_callback: no length for 'just_address_answers': %d\n",
+			gdns_r);
+		goto cleanup;
+	}
+	printf("len %d\n", len);
+	got_ipv4= 0;
+	got_ipv6= 0;
+	for (i= 0; i<len; i++)
+	{
+		gdns_r= getdns_list_get_dict(answer_list, i, &addr_dict);
+		if (gdns_r != GETDNS_RETURN_GOOD)
+		{
+			fprintf(stderr,
+			"dns_callback: no dict at %d: %d\n", i, gdns_r);
+			goto cleanup;
+		}
+		gdns_r= getdns_dict_get_bindata(addr_dict, "address_type",
+			&addr_type);
+		if (gdns_r != GETDNS_RETURN_GOOD)
+		{
+			fprintf(stderr,
+			"dns_callback: address_type at %d: %d\n", i, gdns_r);
+			goto cleanup;
+		}
+		gdns_r= getdns_dict_get_bindata(addr_dict, "address_data",
+			&addr_data);
+		if (gdns_r != GETDNS_RETURN_GOOD)
+		{
+			fprintf(stderr,
+			"dns_callback: address_data at %d: %d\n", i, gdns_r);
+			goto cleanup;
+		}
+		fprintf(stderr, "dns_callback: %d type %.*s\n", i,
+			addr_type->size, addr_type->data);
+
+		if (addr_type->size != 4)
+		{
+			/* Weird address type */
+			continue;
+		}
+
+		if (strncmp(addr_type->data, "IPv4", 4) == 0)
+		{
+			got_ipv4= 1;
+			if (ctxp->naddrs >= MAXADDRS)
+				continue;
+
+			alist= &ctxp->alist[ctxp->naddrs];
+
+			alist->error= 0;
+			alist->socket= -1;
+
+			sin4p= (struct sockaddr_in *)&alist->addr;
+			memset(sin4p, '\0', sizeof(*sin4p));
+			sin4p->sin_family= AF_INET;
+			memcpy(&sin4p->sin_addr, addr_data->data,
+				sizeof(sin4p->sin_addr));
+			sin4p->sin_port= ctxp->port;
+			alist->addrlen= sizeof(*sin4p);
+			ctxp->naddrs++;
+		}
+		else if (strncmp(addr_type->data, "IPv6", 4) == 0)
+		{
+			got_ipv6= 1;
+			if (ctxp->naddrs >= MAXADDRS)
+				continue;
+
+			alist= &ctxp->alist[ctxp->naddrs];
+
+			alist->error= 0;
+			alist->socket= -1;
+
+			sin6p= (struct sockaddr_in6 *)&alist->addr;
+			memset(sin6p, '\0', sizeof(*sin6p));
+			sin6p->sin6_family= AF_INET6;
+			memcpy(&sin6p->sin6_addr, addr_data->data,
+				sizeof(sin6p->sin6_addr));
+			sin6p->sin6_port= ctxp->port;
+			alist->addrlen= sizeof(*sin6p);
+			ctxp->naddrs++;
+		}
+		else
+		{
+			/* Weird address type */
+			continue;
+		}
+	}
+
+	merge_v4_v6(ctxp);
+
+	if (got_ipv4)
+	{
+		switch(ctxp->state)
+		{
+		case STATE_DNS:
+			ctxp->state= STATE_DNS_IPV6_WAITING;
+			ctxp->ipv6_to_event= evtimer_new(ctxp->base->event_base,
+				timeout_callback, ctxp);
+			clock_gettime(CLOCK_MONOTONIC, &timeout);
+			fprintf(stderr, "dns_callback: now %d.%09d\n",
+				timeout.tv_sec, timeout.tv_nsec);
+			timeout.tv_nsec += TIMEOUT_NS % NS_PER_SEC;
+			timeout.tv_sec += TIMEOUT_NS / NS_PER_SEC;
+			fprintf(stderr, "dns_callback: timeout %d.%09d\n",
+				timeout.tv_sec, timeout.tv_nsec);
+			if (timeout.tv_nsec >= NS_PER_SEC)
+			{
+				timeout.tv_nsec -= NS_PER_SEC;
+				timeout.tv_sec++;
+			}
+			fprintf(stderr, "dns_callback: timeout %d.%09d\n",
+				timeout.tv_sec, timeout.tv_nsec);
+			ctxp->ipv6_timeout= timeout;
+
+			/* The timeout callback will set the timer. */
+			timeout_callback(-1, 0, ctxp);
+			break;
+
+		case STATE_DNS_IPV4_CONNECTING:
+			ctxp->state= STATE_CONNECTING;
+
+			fprintf(stderr,
+			"dns_callback: before do_connect, addresses:\n");
+			for (i= 0; i<ctxp->naddrs; i++)
+			{
+				getnameinfo((struct sockaddr *)
+					&ctxp->mlist[i]->addr,
+					ctxp->mlist[i]->addrlen, 
+					addrstr, sizeof(addrstr), NULL, 0,
+					NI_NUMERICHOST);
+				fprintf(stderr, "%s\n", addrstr);
+			}
+			do_connect(ctxp);
+			break;
+
+		default:
+			fprintf(stderr,
+				"dns_callback: unknown state %d (IPv4)\n",
+				ctxp->state);
+			goto cleanup;
+		}
+	}
+	if (got_ipv6)
+	{
+		switch(ctxp->state)
+		{
+		case STATE_DNS:
+			ctxp->state= STATE_DNS_IPV4_CONNECTING;
+			fprintf(stderr,
+			"dns_callback: before do_connect, addresses:\n");
+			for (i= 0; i<ctxp->naddrs; i++)
+			{
+				getnameinfo((struct sockaddr *)
+					&ctxp->mlist[i]->addr,
+					ctxp->mlist[i]->addrlen, 
+					addrstr, sizeof(addrstr), NULL, 0,
+					NI_NUMERICHOST);
+				fprintf(stderr, "%s\n", addrstr);
+			}
+			do_connect(ctxp);
+			break;
+
+		case STATE_DNS_IPV6_WAITING:
+			/* Cancel timer */
+			evtimer_del(ctxp->ipv6_to_event);
+			event_free(ctxp->ipv6_to_event);
+			ctxp->ipv6_to_event= NULL;
+			ctxp->state= STATE_CONNECTING;
+			fprintf(stderr,
+			"dns_callback: before do_connect, addresses:\n");
+			for (i= 0; i<ctxp->naddrs; i++)
+			{
+				getnameinfo((struct sockaddr *)
+					&ctxp->mlist[i]->addr,
+					ctxp->mlist[i]->addrlen, 
+					addrstr, sizeof(addrstr), NULL, 0,
+					NI_NUMERICHOST);
+				fprintf(stderr, "%s\n", addrstr);
+			}
+			do_connect(ctxp);
+			break;
+			
+		default:
+			fprintf(stderr,
+			"dns_callback: unknown state %d (IPv6)\n",
+				ctxp->state);
+			goto cleanup;
+		}
+	}
+cleanup:
+	getdns_dict_destroy(response);
+	response= NULL;
+}
+
+static void timeout_callback(evutil_socket_t fd, short events, void *ref)
+{
+	struct work_ctx *ctxp;
+	struct timespec now;
+	struct timeval timeout;
+
+	ctxp= ref;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	fprintf(stderr, "timeout_callback: now %d.%09d\n",
+		now.tv_sec, now.tv_nsec);
+	fprintf(stderr, "timeout_callback: target %d.%09d\n",
+		ctxp->ipv6_timeout.tv_sec, ctxp->ipv6_timeout.tv_nsec);
+
+	if (now.tv_sec < ctxp->ipv6_timeout.tv_sec ||
+		(now.tv_sec == ctxp->ipv6_timeout.tv_sec &&
+		now.tv_nsec < ctxp->ipv6_timeout.tv_nsec))
+	{
+		/* Set timer */
+		timeout.tv_sec= ctxp->ipv6_timeout.tv_sec - now.tv_sec;
+		timeout.tv_usec= (ctxp->ipv6_timeout.tv_nsec - now.tv_nsec)/
+			1000 + 1;
+
+		fprintf(stderr, "timeout %d.%06d\n",
+			timeout.tv_sec, timeout.tv_usec);
+		if (timeout.tv_usec < 0)
+		{
+			timeout.tv_usec += US_PER_SEC;
+			timeout.tv_sec--;
+		}
+		fprintf(stderr, "timeout %d.%06d\n",
+			timeout.tv_sec, timeout.tv_usec);
+		evtimer_add(ctxp->ipv6_to_event, &timeout);
+		return;
+	}
+
+	/* The state should be STATE_DNS_IPV6_WAITING. Ignore other states */
+	if (ctxp->state != STATE_DNS_IPV6_WAITING)
+	{
+		fprintf(stderr, "timeout_callback: bad state %d\n",
+			ctxp->state);
+		return;
+	}
+
+	/* Start connecting */
+	ctxp->state= STATE_DNS_IPV6_CONNECTING;
+	do_connect(ctxp);
+}
+
+static void connect_callback(evutil_socket_t fd, short events, void *ref)
+{
+	int i, r, error, sock;
+	socklen_t socklen;
+	struct work_ctx *ctxp;
+	struct addrlist *ap;
+	void (*user_cb)(int fd, void *ref);
+	void *user_ref;
+	SSL *tls;
+
+	ctxp= ref;
+
+	/* Just look at all sockets */
+	for (i= 0, ap= ctxp->alist; i<ctxp->naddrs; i++, ap++)
+	{
+		if (ap->socket == fd)
+			break;
+	}
+
+	if (i >= ctxp->naddrs)
+	{
+		/* Weird. */
+		fprintf(stderr, "connect_callback: socket not found\n");
+		return;
+
+	}
+
+	/* Check for error */
+	socklen= sizeof(error);
+	r= getsockopt(fd, SOL_SOCKET, SO_ERROR, &error, &socklen);
+	if (r == -1)
+	{
+		/* Weird */
+		ap->error= errno;
+		do_connect(ctxp);
+		return;
+	}
+	if (error)
+	{
+		ap->error= error;
+		do_connect(ctxp);
+		return;
+	}
+
+	sock= ap->socket;
+
+	assert(ap->event);
+	event_del(ap->event);
+	event_free(ap->event);
+	ap->event= NULL;
+
+	fprintf(stderr,  "connect_callback: starting SSL for fd %d\n", sock);
+
+	if (!ctxp->tls_ctx)
+	{
+		ctxp->tls_ctx= SSL_CTX_new(TLS_method());
+	}
+
+	tls= SSL_new(ctxp->tls_ctx);
+
+	assert(!ap->bev);
+	ap->bev= bufferevent_openssl_socket_new(ctxp->base->event_base,
+		sock, tls, BUFFEREVENT_SSL_CONNECTING, BEV_OPT_CLOSE_ON_FREE);
+
+	bufferevent_setcb(ap->bev, read_callback, write_callback, 
+		event_callback, ctxp);
+
+
+}
+
+static void connect_to_callback(evutil_socket_t fd, short events, void *ref)
+{
+	struct work_ctx *ctxp;
+
+	ctxp= ref;
+
+	fprintf(stderr, "connect_to_callback: restarting connect\n");
+	do_connect(ctxp);
+}
+
+static void read_callback(struct bufferevent *bev, void *ctx)
+{
+	fprintf(stderr, "in read_callback\n");
+}
+
+static void write_callback(struct bufferevent *bev, void *ctx)
+{
+	fprintf(stderr, "in write_callback\n");
+}
+
+static void event_callback(struct bufferevent *bev, short what, void *ref)
+{
+	int i;
+	struct work_ctx *ctxp;
+	struct addrlist *ap;
+	struct bufferevent *lbev;
+
+	ctxp= ref;
+
+	fprintf(stderr, "in event_callback, what 0x%x\n", what);
+
+	if (what != BEV_EVENT_CONNECTED)
+	{
+		fprintf(stderr,
+			"event_callback, TLS connect failed with 0x%x\n",
+			what);
+		
+	}
+
+	/* Kill timers */
+	if (ctxp->ipv6_to_event)
+	{
+		evtimer_del(ctxp->ipv6_to_event);
+		event_free(ctxp->ipv6_to_event);
+		ctxp->ipv6_to_event= NULL;
+	}
+
+	assert(ctxp->connect_to_event);
+	evtimer_del(ctxp->connect_to_event);
+	event_free(ctxp->connect_to_event);
+	ctxp->connect_to_event= NULL;
+
+	/* Find bev */
+	for (i= 0, ap= ctxp->alist; i<ctxp->naddrs; i++, ap++)
+	{
+		if (ap->bev == bev)
+		{
+			/* Found the right event */
+			ap->bev= NULL;
+			ap->socket= -1;
+			continue;
+		}
+		if (!ap->bev)
+		{
+			if (ap->socket != -1)
+			{
+				assert(ap->event);
+				event_del(ap->event);
+				event_free(ap->event);
+				ap->event= NULL;
+
+				close(ap->socket);
+				ap->socket= -1;
+			}
+			continue;
+		}
+
+		lbev= ap->bev;
+		ap->bev= NULL;
+		bufferevent_free(lbev);
+		lbev= NULL;
+	}
+
+	ctxp->user_cb(bev, ctxp->user_ref);
+}
+
+static void merge_v4_v6(struct work_ctx *ctxp)
+{
+	int i, j, any, best, prefer_ipv6;
+	struct addrlist *ap;
+
+	for (i= 0, ap= ctxp->alist; i<ctxp->naddrs; i++, ap++)
+		ap->selected= 0;
+
+	/* Try to interleave IPv4 and IPv6 addresses */
+	prefer_ipv6= 1;
+	for (i= 0; i<ctxp->naddrs; i++)
+	{
+		best= -1;
+		any= -1;
+		for (j= 0, ap= ctxp->alist; j<ctxp->naddrs; j++, ap++)
+		{
+			if (ap->selected)
+				continue;
+
+			if (any == -1)
+				any= j;
+			if (prefer_ipv6)
+			{
+				if (ap->addr.ss_family == AF_INET6)
+				{
+					best= j;
+					prefer_ipv6= 0;	/* IPv4 next time */
+					break;
+				}
+			}
+			else
+			{
+				if (ap->addr.ss_family == AF_INET)
+				{
+					best= j;
+					prefer_ipv6= 1;	/* IPv6 next time */
+					break;
+				}
+			}
+		}
+		if (best != -1)
+		{
+			ctxp->mlist[i]= &ctxp->alist[best];
+			ctxp->alist[best].selected= 1;
+			continue;
+		}
+		assert(any != -1);
+		ctxp->mlist[i]= &ctxp->alist[any];
+		ctxp->alist[any].selected= 1;
+	}
+}
+
+static void do_connect(struct work_ctx *ctxp)
+{
+	int i, r, done, do_timeout;
+	struct addrlist *ap;
+	struct timespec now, timeout_ns;
+	struct timeval timeout;
+
+	done= 1;	/* Assume we are done. Will be cleared when
+			 * there is work to do.
+			 */
+	do_timeout= 0;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	for (i= 0; i<ctxp->naddrs; i++)
+	{
+		ap= ctxp->mlist[i];
+
+		if (ap->error)
+		{
+			continue;	/* This address already
+					 * failed.
+					 */
+		}
+
+		if (ap->socket == -1)
+		{
+			r= socket(ap->addr.ss_family, SOCK_STREAM, 0);
+			if (r == -1)
+			{
+				ap->error= errno;
+				continue;
+			}
+
+			ap->socket= r;
+
+			/* Switch to nonblocking */
+			fcntl(ap->socket, F_SETFL,
+				fcntl(ap->socket, F_GETFL) |
+				O_NONBLOCK);
+
+			r= connect(ap->socket, (struct sockaddr *)&ap->addr,
+				ap->addrlen);
+			if (r == 0)
+			{
+				/* This is weird, a nonblocking
+				 * connect that succeeds. In any case,
+				 * we got what we wanted.
+				 */
+				done= 1; /* signal that we are done */
+				break;
+			}
+			else if (errno == EINPROGRESS)
+			{
+				/* This is what we expect, fall
+				 * through.
+				 */
+			}
+			else
+			{
+				/* Some kind of error */
+				ap->error= errno;
+				continue;
+			}
+
+			ap->timeout= 0;
+			ap->endtime= now;
+			ts_add_ns(&ap->endtime, TIMEOUT_NS);
+
+			assert(!ap->event);
+			ap->event= event_new(ctxp->base->event_base,
+				ap->socket, EV_WRITE, connect_callback, ctxp);
+			event_add(ap->event, NULL);
+		}
+
+		assert(ap->socket != -1 && ap->error == 0);
+		done= 0;
+
+		if (!ap->timeout)
+		{
+			if (ap->endtime.tv_sec < now.tv_sec ||
+				(ap->endtime.tv_sec == now.tv_sec &&
+				ap->endtime.tv_nsec <= now.tv_nsec))
+			{
+				/* We got a timeout, move to the
+				 * next address.
+				 */
+				ap->timeout= 1;
+				continue;
+			}
+
+			ts_sub(&timeout_ns, &ap->endtime, &now);
+			tv_from_ts(&timeout, &timeout_ns);
+			do_timeout= 1;
+			break;
+		}
+	}
+
+	if (done)
+	{
+		if (i < ctxp->naddrs)
+		{
+			fprintf(stderr, "do_connect: found one\n");
+			return;	/* Got something */
+		}
+
+		/* All addresses failed. */
+		fprintf(stderr, "do_connect: all failed\n");
+		assert(ctxp->alist[0].error);
+		return;
+	}
+
+	if (do_timeout)
+	{
+		if (!ctxp->connect_to_event)
+		{
+			ctxp->connect_to_event=
+				evtimer_new(ctxp->base->event_base,
+				connect_to_callback, ctxp);
+		}
+		evtimer_add(ctxp->connect_to_event, &timeout);
+	}
+
+}
+
+static void ts_add_ns(struct timespec *tsp, long ns)
+{
+	tsp->tv_sec += TIMEOUT_NS / NS_PER_SEC;
+	tsp->tv_nsec += TIMEOUT_NS % NS_PER_SEC;
+	if (tsp->tv_nsec >= NS_PER_SEC)
+	{
+		tsp->tv_nsec -= NS_PER_SEC;
+		tsp->tv_sec++;
+	}
+}
+
+static void ts_sub(struct timespec *res,
+	struct timespec *v1, struct timespec *v2)
+{
+	res->tv_sec= v1->tv_sec-v2->tv_sec;
+	res->tv_nsec= v1->tv_nsec-v2->tv_nsec;
+	if (res->tv_nsec < 0)
+	{
+		res->tv_nsec += NS_PER_SEC;
+		res->tv_sec--;
+	}
+}
+
+static void tv_from_ts(struct timeval *tv, struct timespec *ts)
+{
+	tv->tv_sec= ts->tv_sec;
+	tv->tv_usec= ts->tv_nsec/1000;
+	if (ts->tv_nsec % 1000)
+		tv->tv_usec++;	/* Round up */
+}

--- a/proto5/connectbyname.h
+++ b/proto5/connectbyname.h
@@ -1,0 +1,28 @@
+/*
+connectbyname.h
+
+Interface for connectbyname
+*/
+
+#include <getdns/getdns.h>
+
+struct cbn_context
+{
+	struct event_base *event_base;
+	getdns_context *getdns_ctx;
+};
+
+struct bufferevent;
+typedef void (*cbn_callback_T)(struct bufferevent *bev, void *ref);
+
+int cbn_init(struct cbn_context *cbn_ctx, struct event_base *event_base);
+void cbn_clean(struct cbn_context *cbn_ctx);
+
+int connectbyname(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname, int *fdp);
+
+int connectbyname_asyn(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname,
+	cbn_callback_T user_cb, void *user_ref, void **refp);
+
+void connectbyname_free(void *ref);

--- a/proto5/get443.c
+++ b/proto5/get443.c
@@ -1,0 +1,168 @@
+/*
+get443.c
+
+Send a HTTP GET request to a target and print the result.
+*/
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+
+#include <event2/event.h>
+#include <event2/bufferevent.h>
+
+#include "connectbyname.h"
+
+struct state
+{
+	char *hostname;
+	struct event_base *event_base;
+	struct event *event;
+	void *cbn_ref;
+
+	struct cbn_context cbn_ctx;
+};
+
+static void callback(struct bufferevent *bev, void *ref);
+static void read_callback(struct bufferevent *bev, void *ref);
+static void event_callback(struct bufferevent *bev, short what, void *ref);
+static void usage(void);
+
+int main(int argc, char *argv[])
+{
+	int r, s;
+	FILE *f;
+	char *hostname;
+	void *ref;
+	struct event_base *event_base;
+	char buf[1024];
+	struct state state;
+
+	if (argc != 2)
+		usage();
+
+	hostname= argv[1];
+	state.hostname= hostname;
+
+	event_enable_debug_mode();
+	event_base= event_base_new();
+	state.event_base= event_base;
+	cbn_init(&state.cbn_ctx, event_base);
+	r= connectbyname_asyn(&state.cbn_ctx, hostname, "https",
+		callback, &state, &ref);
+	if (r)
+	{
+		fprintf(stderr, "connectbyname failed: %d\n", r);
+		exit(1);
+	}
+	fprintf(stderr, "main: &state: %p, ref %p\n", &state, ref);
+	state.cbn_ref= ref;
+
+	r= event_base_dispatch(event_base);
+	fprintf(stderr, "event_base_dispatch returned: %d\n", r);
+	abort();
+
+	f= fdopen(s, "r+");
+	if (f == NULL)
+	{
+		fprintf(stderr, "fdopen failed: %s\n", strerror(errno));
+		exit(1);
+	}
+	fprintf(f, "GET / HTTP/1.1\r\nHost: %s\r\n\r\n", hostname);
+	fflush(f);
+	shutdown(s, SHUT_WR);
+	for(;;)
+	{
+		r= fread(buf, 1, sizeof(buf), f);
+		if (r == 0)
+		{
+			if (feof(f))
+				break;
+			fprintf(stderr, "read error: %s\n", strerror(errno));
+			exit(1);
+		}
+		fwrite(buf, r, 1, stdout);
+	}
+	fclose(f);
+	exit(0);
+}
+
+static void callback(struct bufferevent *bev, void *ref)
+{
+	struct state *statep;
+	char reqline[80];
+
+	statep= ref;
+
+	snprintf(reqline, sizeof(reqline),
+		"GET / HTTP/1.1\r\nHost: %s\r\n\r\n", statep->hostname);
+	
+	/* Assume write will not block */
+	bufferevent_write(bev, reqline, strlen(reqline));
+	bufferevent_enable(bev, EV_READ);
+	bufferevent_setcb(bev, read_callback, NULL, event_callback, ref);
+}
+
+static void read_callback(struct bufferevent *bev, void *ref)
+{
+	int r;
+	char line[1024];
+
+	printf("\n\nin read_callback\n\n");
+
+	for (;;)
+	{
+		r= bufferevent_read(bev, line, sizeof(line));
+		if (r == 0)
+			break;
+		if (r == -1)
+		{
+			fprintf(stderr, "read error %s\n", strerror(errno));
+			exit(1);
+		}
+		printf("%.*s", r, line);
+	}
+}
+
+static void event_callback(struct bufferevent *bev, short what, void *ref)
+{
+	struct state *statep;
+
+	statep= ref;
+
+	if ((what & (BEV_EVENT_READING|BEV_EVENT_EOF)) ==
+		(BEV_EVENT_READING|BEV_EVENT_EOF))
+	{
+		/* EOF */
+
+		/* Free bufferevent */
+		bufferevent_free(bev);
+		bev= NULL;
+
+		fprintf(stderr, "event_callback: statep: %p, ref %p\n",
+			statep, statep->cbn_ref);
+		
+		/* Connectbyname call */
+		connectbyname_free(statep->cbn_ref);
+		statep->cbn_ref= NULL;
+
+		/* Connectbyname context */
+		cbn_clean(&statep->cbn_ctx);
+
+		/* event base */
+		event_base_free(statep->event_base);
+		statep->event_base= NULL;
+
+		exit(0);
+	}
+	fprintf(stderr, "event_callback: what %d\n", what);
+}
+
+static void usage(void)
+{
+	fprintf(stderr, "get80 <hostname>\n");
+	exit(1);
+}

--- a/proto6/Makefile
+++ b/proto6/Makefile
@@ -1,0 +1,17 @@
+LIBEVENT=/home/philip/src/libevent-2.1.11-stable
+
+CFLAGS=-g -I$(LIBEVENT)/include
+LDFLAGS=-static -g -L$(LIBEVENT)/.libs
+LDFLAGS=-g -L$(LIBEVENT)/.libs
+LIBS=-levent -levent_openssl -lssl /usr/lib/x86_64-linux-gnu/libgetdns_ex_event.a -L /home/philip/src/getdns -Wl,-rpath=/home/philip/src/getdns -lgetdns /home/philip/src/ldns/.libs/libldns.a -lcrypto
+
+
+all:	get443_6
+
+GET443_6_OBJ=get443.o connectbyname.o
+
+get443_6: $(GET443_6_OBJ)
+	$(CC) $(LDFLAGS) -o $@ $(GET443_6_OBJ) $(LIBS)
+
+clean:
+	rm -f get443_6 $(GET443_6_OBJ)

--- a/proto6/README
+++ b/proto6/README
@@ -1,0 +1,5 @@
+Prototype based on libevent, use getdns for name resolution,
+then connect using happy eyeballs to avoid waiting too long for a connect to
+fail. Create an SSL bufferevent and wait for the buffer to become writable.
+Also, send a TLSA request and verify the server key if a DNSSEC secure reply
+arrives.

--- a/proto6/connectbyname.c
+++ b/proto6/connectbyname.c
@@ -1,0 +1,1343 @@
+/*
+connectbyname.c
+
+Implementation of connectbyname
+*/
+
+#include <assert.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <event2/event.h>
+#include <event2/dns.h>
+#include <event2/bufferevent_ssl.h>
+
+#include <openssl/ssl.h>
+
+#include <getdns/getdns_ext_libevent.h>
+
+#include <ldns/ldns.h>
+
+#include "connectbyname.h"
+
+#define MAXADDRS	16
+#define TIMEOUT_NS	  25000000	/* 25 ms */
+#if 1
+#undef TIMEOUT_NS
+#define TIMEOUT_NS	5000000000	
+#endif
+#define US_PER_SEC	   1000000	/* Microseconds in a second */
+#define NS_PER_SEC	1000000000	/* Nanoseconds in a second */
+
+struct addrlist
+{
+	int timeout;
+	int error;
+	int socket;
+	int selected;
+	int tls_completed;
+	struct sockaddr_storage addr;
+	socklen_t addrlen;
+	struct timespec endtime;
+	struct event *event;
+	struct bufferevent *bev;
+};
+
+struct work_ctx
+{
+	unsigned port;			/* Port number to connect to */
+	cbn_callback_T user_cb;
+	void *user_ref;
+
+	unsigned state;
+	getdns_transaction_t trans_id_ipv4;
+	getdns_transaction_t trans_id_ipv6;
+	getdns_transaction_t trans_id_dane;
+	struct addrlist alist[MAXADDRS];
+	unsigned naddrs;
+	struct addrlist *mlist[MAXADDRS];
+
+	/* Completed tls connections are stored here */
+	unsigned ntls;
+	struct bufferevent *tls_bev[MAXADDRS];
+
+	/* If IPv4 address arrive first, we wait a bit for the IPv6 addresses
+	 * to arrive. If the time expires, we start connecting to the IPv4
+	 * addresses.
+	 */
+	struct event *ipv6_to_event;
+	struct timespec ipv6_timeout;
+
+	/* Event for connect timeout */
+	struct event *connect_to_event;
+
+	SSL_CTX *tls_ctx;
+
+	/* The DANE module checks TLS connections one by one. */
+	int dane_status;
+	ldns_rr_list *dane_rr_list;
+	struct bufferevent *dane_tls_bev;
+
+	/* Record if we passed a connection to the user. True if we passed
+	 * a connection to the user. False if the user never got anything 
+	 * or asked for more.
+	 */
+	int user_busy;
+
+	struct cbn_context *base;
+};
+
+#define STATE_INITIAL			0
+#define STATE_DNS			1
+#define STATE_DNS_IPV4_CONNECTING	2
+#define STATE_DNS_IPV6_WAITING		3
+#define STATE_DNS_IPV6_CONNECTING	4
+#define STATE_CONNECTING		5
+
+#define DANE_UNKNOWN			0
+#define DANE_NO				1	/* No TLSA records */
+#define DANE_PRESENT			2	/* TLSA record(s) present */
+
+static void dns_callback(getdns_context *context,
+	getdns_callback_type_t callback_type,
+	getdns_dict *response,
+	void *userarg,
+	getdns_transaction_t transaction_id);
+static void dane_callback(getdns_context *context,
+	getdns_callback_type_t callback_type,
+	getdns_dict *response,
+	void *userarg,
+	getdns_transaction_t transaction_id);
+static void timeout_callback(evutil_socket_t fd, short events, void *ref);
+static void connect_callback(evutil_socket_t fd, short events, void *ref);
+static void connect_to_callback(evutil_socket_t fd, short events, void *ref);
+static void read_callback(struct bufferevent *bev, void *ref);
+static void write_callback(struct bufferevent *bev, void *ref);
+static void event_callback(struct bufferevent *bev, short what, void *ref);
+static void merge_v4_v6(struct work_ctx *ctxp);
+static void do_connect(struct work_ctx *ctxp);
+static struct bufferevent *tls_get(struct work_ctx *ctxp);
+static void dane_check(struct work_ctx *ctxp);
+static void ts_add_ns(struct timespec *tsp, long ns);
+static void ts_sub(struct timespec *res,
+	struct timespec *v1, struct timespec *v2);
+static void tv_from_ts(struct timeval *tv, struct timespec *ts);
+
+int cbn_init(struct cbn_context *cbn_ctx, struct event_base *event_base)
+{
+	memset(cbn_ctx, '\0', sizeof(*cbn_ctx));
+	cbn_ctx->event_base= event_base;
+	return 0;
+}
+
+void cbn_clean(struct cbn_context *cbn_ctx)
+{
+	getdns_context_destroy(cbn_ctx->getdns_ctx);
+	cbn_ctx->getdns_ctx= NULL;
+	cbn_ctx->event_base= NULL;
+}
+
+int connectbyname_asyn(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname,
+	cbn_callback_T user_cb, void *user_ref, void **refp)
+{
+	int r, flags;
+	getdns_return_t gdns_r;
+	unsigned long port_ul;
+	char *next;
+	struct servent *se;
+	struct work_ctx *work_ctx;
+	getdns_dict *extensions;
+	char danename[256];
+
+	/* Parse servname */
+	port_ul= strtoul(servname, &next, 10);
+	if (next[0] == '\0')
+	{
+		if (port_ul == 0 || port_ul >= 0x10000)
+		{
+			/* XXX should convert error */
+			return -1;
+		}
+		port_ul= htons(port_ul);
+	}
+	else
+	{
+		se= getservbyname(servname, "tcp");
+		if (se == NULL)
+			return -1;	/* XXX convert error */
+		port_ul= se->s_port;
+	}
+
+	assert(cbn_ctx->event_base);
+
+	gdns_r= getdns_context_create(&cbn_ctx->getdns_ctx, 1);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr, "getdns_context_create failed\n");
+		return -1;
+	}
+
+	gdns_r= getdns_extension_set_libevent_base(cbn_ctx->getdns_ctx,
+		cbn_ctx->event_base);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr, "getdns_context_create failed\n");
+		return -1;
+	}
+	
+	work_ctx= malloc(sizeof(*work_ctx));
+	fprintf(stderr, "connectbyname_asyn: work_ctx = %p\n", work_ctx);
+	memset(work_ctx, '\0', sizeof(*work_ctx));
+	work_ctx->base= cbn_ctx;
+	work_ctx->port= port_ul;
+	work_ctx->user_cb= user_cb;
+	work_ctx->user_ref= user_ref;
+
+	work_ctx->state= STATE_INITIAL;
+	work_ctx->dane_status= DANE_UNKNOWN;
+
+	work_ctx->state= STATE_DNS;
+	gdns_r= getdns_general(cbn_ctx->getdns_ctx,
+		hostname, GETDNS_RRTYPE_AAAA,
+		NULL, work_ctx, &work_ctx->trans_id_ipv6,
+		dns_callback);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr, "getdns_general failed\n");
+		return -1;
+	}
+	gdns_r= getdns_general(cbn_ctx->getdns_ctx,
+		hostname, GETDNS_RRTYPE_A,
+		NULL, work_ctx, &work_ctx->trans_id_ipv4,
+		dns_callback);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr, "getdns_general failed\n");
+		return -1;
+	}
+
+	extensions = getdns_dict_create();
+	gdns_r = getdns_dict_set_int(extensions, "dnssec_return_status",
+		GETDNS_EXTENSION_TRUE);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr, "getdns_dict_set_int failed\n");
+		return -1;
+	}
+#if 1
+	gdns_r = getdns_dict_set_int(extensions, "dnssec_return_validation_chain",
+		GETDNS_EXTENSION_TRUE);
+#endif
+
+	r= snprintf(danename, sizeof(danename), "_%u._tcp.%s",
+		ntohs(port_ul), hostname);
+	if (r >= sizeof(danename))
+	{
+		fprintf(stderr, "DANE name too big for buffer\n");
+		return -1;
+	}
+	gdns_r= getdns_general(cbn_ctx->getdns_ctx,
+		danename, GETDNS_RRTYPE_TLSA,
+		extensions, work_ctx, &work_ctx->trans_id_dane,
+		dane_callback);
+	getdns_dict_destroy(extensions);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr, "getdns_general failed\n");
+		return -1;
+	}
+
+	*refp= work_ctx;
+	return 0;
+}
+
+void connectbyname_free(void *ref)
+{
+	struct work_ctx *ctxp;
+
+	ctxp= ref;
+	fprintf(stderr, "connectbyname_free: ctxp = %p\n", ctxp);
+
+	/* We should check what needs to be freed or canceled */
+
+	free(ctxp);
+	ctxp= NULL;
+}
+
+static void dns_callback(getdns_context *context,
+	getdns_callback_type_t callback_type,
+	getdns_dict *response,
+	void *userarg,
+	getdns_transaction_t transaction_id)
+{
+#if 0
+	uint8_t (*addrs4)[4];
+	uint8_t (*addrs6)[16];
+#endif
+	int i, got_ipv4, got_ipv6;
+	getdns_return_t gdns_r;
+	size_t len;
+	struct work_ctx *ctxp;
+	getdns_list *answer_list;
+	getdns_dict *addr_dict;
+	getdns_bindata *addr_type;
+	getdns_bindata *addr_data;
+	struct addrlist *alist;
+	struct sockaddr_in *sin4p;
+	struct sockaddr_in6 *sin6p;
+	struct timespec timeout;
+	char addrstr[INET6_ADDRSTRLEN];
+
+	ctxp= userarg;
+	if (callback_type != GETDNS_CALLBACK_COMPLETE)
+	{
+		/* Should handle DNS errors */
+		fprintf(stderr, "dns_callback, callback_type %d\n",
+			callback_type);
+		goto cleanup;
+	}
+
+#if 0
+	printf("dns_callback: got\n");
+	printf("%s\n", getdns_pretty_print_dict(response));
+#endif
+	
+	gdns_r= getdns_dict_get_list(response, "just_address_answers",
+		&answer_list);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr,
+		"dns_callback: nothing for 'just_address_answers': %d\n",
+			gdns_r);
+		goto cleanup;
+	}
+	gdns_r= getdns_list_get_length(answer_list, &len);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr,
+		"dns_callback: no length for 'just_address_answers': %d\n",
+			gdns_r);
+		goto cleanup;
+	}
+	printf("len %d\n", len);
+	got_ipv4= 0;
+	got_ipv6= 0;
+	for (i= 0; i<len; i++)
+	{
+		gdns_r= getdns_list_get_dict(answer_list, i, &addr_dict);
+		if (gdns_r != GETDNS_RETURN_GOOD)
+		{
+			fprintf(stderr,
+			"dns_callback: no dict at %d: %d\n", i, gdns_r);
+			goto cleanup;
+		}
+		gdns_r= getdns_dict_get_bindata(addr_dict, "address_type",
+			&addr_type);
+		if (gdns_r != GETDNS_RETURN_GOOD)
+		{
+			fprintf(stderr,
+			"dns_callback: address_type at %d: %d\n", i, gdns_r);
+			goto cleanup;
+		}
+		gdns_r= getdns_dict_get_bindata(addr_dict, "address_data",
+			&addr_data);
+		if (gdns_r != GETDNS_RETURN_GOOD)
+		{
+			fprintf(stderr,
+			"dns_callback: address_data at %d: %d\n", i, gdns_r);
+			goto cleanup;
+		}
+		fprintf(stderr, "dns_callback: %d type %.*s\n", i,
+			addr_type->size, addr_type->data);
+
+		if (addr_type->size != 4)
+		{
+			/* Weird address type */
+			continue;
+		}
+
+		if (strncmp(addr_type->data, "IPv4", 4) == 0)
+		{
+			got_ipv4= 1;
+			if (ctxp->naddrs >= MAXADDRS)
+				continue;
+
+			alist= &ctxp->alist[ctxp->naddrs];
+
+			alist->error= 0;
+			alist->socket= -1;
+			alist->tls_completed= 0;
+
+			sin4p= (struct sockaddr_in *)&alist->addr;
+			memset(sin4p, '\0', sizeof(*sin4p));
+			sin4p->sin_family= AF_INET;
+			memcpy(&sin4p->sin_addr, addr_data->data,
+				sizeof(sin4p->sin_addr));
+			sin4p->sin_port= ctxp->port;
+			alist->addrlen= sizeof(*sin4p);
+			ctxp->naddrs++;
+		}
+		else if (strncmp(addr_type->data, "IPv6", 4) == 0)
+		{
+			got_ipv6= 1;
+			if (ctxp->naddrs >= MAXADDRS)
+				continue;
+
+			alist= &ctxp->alist[ctxp->naddrs];
+
+			alist->error= 0;
+			alist->socket= -1;
+			alist->tls_completed= 0;
+
+			sin6p= (struct sockaddr_in6 *)&alist->addr;
+			memset(sin6p, '\0', sizeof(*sin6p));
+			sin6p->sin6_family= AF_INET6;
+			memcpy(&sin6p->sin6_addr, addr_data->data,
+				sizeof(sin6p->sin6_addr));
+			sin6p->sin6_port= ctxp->port;
+			alist->addrlen= sizeof(*sin6p);
+			ctxp->naddrs++;
+		}
+		else
+		{
+			/* Weird address type */
+			continue;
+		}
+	}
+
+	merge_v4_v6(ctxp);
+
+	if (got_ipv4)
+	{
+		switch(ctxp->state)
+		{
+		case STATE_DNS:
+			ctxp->state= STATE_DNS_IPV6_WAITING;
+			ctxp->ipv6_to_event= evtimer_new(ctxp->base->event_base,
+				timeout_callback, ctxp);
+			clock_gettime(CLOCK_MONOTONIC, &timeout);
+			fprintf(stderr, "dns_callback: now %d.%09d\n",
+				timeout.tv_sec, timeout.tv_nsec);
+			timeout.tv_nsec += TIMEOUT_NS % NS_PER_SEC;
+			timeout.tv_sec += TIMEOUT_NS / NS_PER_SEC;
+			fprintf(stderr, "dns_callback: timeout %d.%09d\n",
+				timeout.tv_sec, timeout.tv_nsec);
+			if (timeout.tv_nsec >= NS_PER_SEC)
+			{
+				timeout.tv_nsec -= NS_PER_SEC;
+				timeout.tv_sec++;
+			}
+			fprintf(stderr, "dns_callback: timeout %d.%09d\n",
+				timeout.tv_sec, timeout.tv_nsec);
+			ctxp->ipv6_timeout= timeout;
+
+			/* The timeout callback will set the timer. */
+			timeout_callback(-1, 0, ctxp);
+			break;
+
+		case STATE_DNS_IPV4_CONNECTING:
+			ctxp->state= STATE_CONNECTING;
+
+			fprintf(stderr,
+			"dns_callback: before do_connect, addresses:\n");
+			for (i= 0; i<ctxp->naddrs; i++)
+			{
+				getnameinfo((struct sockaddr *)
+					&ctxp->mlist[i]->addr,
+					ctxp->mlist[i]->addrlen, 
+					addrstr, sizeof(addrstr), NULL, 0,
+					NI_NUMERICHOST);
+				fprintf(stderr, "%s\n", addrstr);
+			}
+			do_connect(ctxp);
+			break;
+
+		default:
+			fprintf(stderr,
+				"dns_callback: unknown state %d (IPv4)\n",
+				ctxp->state);
+			goto cleanup;
+		}
+	}
+	if (got_ipv6)
+	{
+		switch(ctxp->state)
+		{
+		case STATE_DNS:
+			ctxp->state= STATE_DNS_IPV4_CONNECTING;
+			fprintf(stderr,
+			"dns_callback: before do_connect, addresses:\n");
+			for (i= 0; i<ctxp->naddrs; i++)
+			{
+				getnameinfo((struct sockaddr *)
+					&ctxp->mlist[i]->addr,
+					ctxp->mlist[i]->addrlen, 
+					addrstr, sizeof(addrstr), NULL, 0,
+					NI_NUMERICHOST);
+				fprintf(stderr, "%s\n", addrstr);
+			}
+			do_connect(ctxp);
+			break;
+
+		case STATE_DNS_IPV6_WAITING:
+			/* Cancel timer */
+			evtimer_del(ctxp->ipv6_to_event);
+			event_free(ctxp->ipv6_to_event);
+			ctxp->ipv6_to_event= NULL;
+			ctxp->state= STATE_CONNECTING;
+			fprintf(stderr,
+			"dns_callback: before do_connect, addresses:\n");
+			for (i= 0; i<ctxp->naddrs; i++)
+			{
+				getnameinfo((struct sockaddr *)
+					&ctxp->mlist[i]->addr,
+					ctxp->mlist[i]->addrlen, 
+					addrstr, sizeof(addrstr), NULL, 0,
+					NI_NUMERICHOST);
+				fprintf(stderr, "%s\n", addrstr);
+			}
+			do_connect(ctxp);
+			break;
+			
+		default:
+			fprintf(stderr,
+			"dns_callback: unknown state %d (IPv6)\n",
+				ctxp->state);
+			goto cleanup;
+		}
+	}
+cleanup:
+	getdns_dict_destroy(response);
+	response= NULL;
+}
+
+static struct bufferevent *tls_get(struct work_ctx *ctxp)
+{
+	struct bufferevent *bev;
+
+	if (ctxp->ntls > 0)
+	{
+		/* We got more tls connection avaible */
+		ctxp->ntls--;
+		bev= ctxp->tls_bev[ctxp->ntls];
+		ctxp->tls_bev[ctxp->ntls]= NULL;
+
+		return bev;
+	}
+
+	/* Restart connect */
+	do_connect(ctxp);
+	return NULL;
+}
+
+static void dane_callback(getdns_context *context,
+	getdns_callback_type_t callback_type,
+	getdns_dict *response,
+	void *userarg,
+	getdns_transaction_t transaction_id)
+{
+	int b, i, j, status, type;
+	size_t answers_len, replies_tree_len;
+	uint32_t u32;
+	struct work_ctx *ctxp;
+	getdns_return_t gdns_r;
+	ldns_status ldns_r;
+	getdns_dict *answer, *reply;
+	getdns_list *answers, *replies_tree;
+	ldns_rr_list *rr_list;
+	ldns_rr *rr;
+	ldns_rdf *rdf;
+	getdns_bindata *bindata;
+	struct bufferevent *bev;
+
+	ctxp= userarg;
+	if (callback_type != GETDNS_CALLBACK_COMPLETE)
+	{
+		/* Should handle DNS errors */
+		fprintf(stderr, "dane_callback, callback_type %d\n",
+			callback_type);
+		goto cleanup;
+	}
+
+#if 0
+	printf("dane_callback: got\n");
+	printf("%s\n", getdns_pretty_print_dict(response));
+	fflush(stdout);
+#endif
+
+	rr_list= NULL;
+
+	gdns_r= getdns_dict_get_list(response, "replies_tree", &replies_tree);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr,
+		"dane_callback: nothing for 'replies_tree': %d\n",
+			gdns_r);
+		goto cleanup;
+	}
+	gdns_r= getdns_list_get_length(replies_tree, &replies_tree_len);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr,
+		"dane_callback: no length of 'replies_tree': %d\n",
+			gdns_r);
+		goto cleanup;
+	}
+	for (i= 0; i<replies_tree_len; i++)
+	{
+		gdns_r= getdns_list_get_dict(replies_tree, i, &reply);
+		if (gdns_r != GETDNS_RETURN_GOOD)
+		{
+			fprintf(stderr,
+			"dane_callback: nothing for 'replies_tree[%d]': %d\n",
+				i, gdns_r);
+			goto cleanup;
+		}
+		gdns_r= getdns_dict_get_list(reply, "answer", &answers);
+		if (gdns_r != GETDNS_RETURN_GOOD)
+		{
+			fprintf(stderr,
+		"dane_callback: nothing for 'replies_tree[%d].answer': %d\n",
+				i, gdns_r);
+			goto cleanup;
+		}
+		gdns_r= getdns_list_get_length(answers, &answers_len);
+		if (gdns_r != GETDNS_RETURN_GOOD)
+		{
+			fprintf(stderr,
+			"dane_callback: no length of 'answers': %d\n",
+				gdns_r);
+			goto cleanup;
+		}
+		for (j= 0; j<answers_len; j++)
+		{
+			gdns_r= getdns_list_get_dict(answers, j, &answer);
+			if (gdns_r != GETDNS_RETURN_GOOD)
+			{
+				fprintf(stderr,
+	"dane_callback: nothing for 'replies_tree[%d].answer[%d]': %d\n",
+					i, j, gdns_r);
+				goto cleanup;
+			}
+			gdns_r= getdns_dict_get_int(answer, "type", &type);
+			if (gdns_r != GETDNS_RETURN_GOOD)
+			{
+				fprintf(stderr,
+	"dane_callback: nothing for 'replies_tree[%d].answer[%d].type': %d\n",
+					i, j, gdns_r);
+				goto cleanup;
+			}
+			if (type != GETDNS_RRTYPE_TLSA)
+				continue;
+#if 0
+	fprintf(stderr, "dane_callback: got\n");
+	fprintf(stderr, "%s\n", getdns_pretty_print_dict(response));
+#endif
+			if (!rr_list)
+			{
+				rr_list= ldns_rr_list_new();
+			}
+			rr= ldns_rr_new_frm_type(LDNS_RR_TYPE_TLSA);
+
+			gdns_r= getdns_dict_get_int(answer,
+				"/rdata/certificate_usage", &u32);
+			if (gdns_r != GETDNS_RETURN_GOOD)
+			{
+				fprintf(stderr,
+"dane_callback: nothing for 'replies_tree[%d].answer[%d].rdata.certificate_usage': %d\n",
+					i, j, gdns_r);
+				goto cleanup;
+			}
+			rdf= ldns_native2rdf_int8(LDNS_RDF_TYPE_UNKNOWN, u32);
+			if (!rdf)
+			{
+				fprintf(stderr,
+			"dane_callback: ldns_native2rdf_int8 failed\n");
+				goto cleanup;
+			}
+			ldns_rr_set_rdf(rr, rdf, 0);
+
+			gdns_r= getdns_dict_get_int(answer,
+				"/rdata/selector", &u32);
+			if (gdns_r != GETDNS_RETURN_GOOD)
+			{
+				fprintf(stderr,
+"dane_callback: nothing for 'replies_tree[%d].answer[%d].rdata.selector': %d\n",
+					i, j, gdns_r);
+				goto cleanup;
+			}
+			rdf= ldns_native2rdf_int8(LDNS_RDF_TYPE_UNKNOWN, u32);
+			if (!rdf)
+			{
+				fprintf(stderr,
+			"dane_callback: ldns_native2rdf_int8 failed\n");
+				goto cleanup;
+			}
+			ldns_rr_set_rdf(rr, rdf, 1);
+
+			gdns_r= getdns_dict_get_int(answer,
+				"/rdata/matching_type", &u32);
+			if (gdns_r != GETDNS_RETURN_GOOD)
+			{
+				fprintf(stderr,
+"dane_callback: nothing for 'replies_tree[%d].answer[%d].rdata.matching_type': %d\n",
+					i, j, gdns_r);
+				goto cleanup;
+			}
+			rdf= ldns_native2rdf_int8(LDNS_RDF_TYPE_UNKNOWN, u32);
+			if (!rdf)
+			{
+				fprintf(stderr,
+			"dane_callback: ldns_native2rdf_int8 failed\n");
+				goto cleanup;
+			}
+			ldns_rr_set_rdf(rr, rdf, 2);
+
+			gdns_r= getdns_dict_get_bindata(answer,
+				"/rdata/certificate_association_data",
+				&bindata);
+			if (gdns_r != GETDNS_RETURN_GOOD)
+			{
+				fprintf(stderr,
+"dane_callback: nothing for 'replies_tree[%d].answer[%d].rdata.certificate_association_data': %d\n",
+					i, j, gdns_r);
+				goto cleanup;
+			}
+			rdf= ldns_rdf_new_frm_data(LDNS_RDF_TYPE_UNKNOWN,
+				bindata->size, bindata->data);
+			if (!rdf)
+			{
+				fprintf(stderr,
+			"dane_callback: ldns_rdf_new_frm_data failed\n");
+				goto cleanup;
+			}
+			ldns_rr_set_rdf(rr, rdf, 3);
+
+			b= ldns_rr_list_push_rr(rr_list, rr); rr= NULL;
+			if (!b)
+			{
+				fprintf(stderr,
+			"dane_callback: ldns_rr_list_push_rr failed\n");
+				goto cleanup;
+			}
+		}
+	}
+
+	if (rr_list)
+	{
+		ctxp->dane_rr_list= rr_list;
+		ctxp->dane_status= DANE_PRESENT;
+		rr_list= NULL;
+	}
+	else
+	{
+		/* No TLSA record */
+		ctxp->dane_status= DANE_NO;
+		goto cleanup;
+	}
+
+	gdns_r= getdns_dict_get_int(response, "status",
+		&status);
+	if (gdns_r != GETDNS_RETURN_GOOD)
+	{
+		fprintf(stderr,
+		"dane_callback: nothing for 'status': %d\n",
+			gdns_r);
+		goto cleanup;
+	}
+
+	switch(status)
+	{
+	case GETDNS_RESPSTATUS_GOOD:
+		break;
+	default:
+		fprintf(stderr, "dane_callback: unknown status %d\n", status);
+		goto cleanup;
+	}
+
+	while(ctxp->dane_tls_bev)
+	{
+		dane_check(ctxp);
+		assert(!ctxp->dane_tls_bev);
+
+		if (ctxp->user_busy)
+			break;	/* No need for me connections */
+
+		fprintf(stderr, "dane_callback: calling tls_get\n");
+		ctxp->dane_tls_bev= tls_get(ctxp);
+	}
+
+cleanup:
+	getdns_dict_destroy(response);
+	response= NULL;
+}
+
+static void dane_check(struct work_ctx *ctxp)
+{
+	ldns_status ldns_r;
+	SSL *ssl;
+	X509* cert;
+	X509_STORE *store;
+	struct bufferevent *bev;
+
+	if (ctxp->user_busy)
+	{
+		/* We already passed a connection to the user. Wait until
+		 * the user asks for more.
+		 */
+		fprintf(stderr, "dane_check: user already busy\n");
+		return;
+	}
+
+	switch (ctxp->dane_status)
+	{
+	case DANE_UNKNOWN:
+		/* No DANE record yet. */
+		return;
+
+	case DANE_PRESENT:
+		/* We have a DANE record. Check. */
+		break;
+
+	default:
+		fprintf(stderr, "dane_check: unknown dane_status %d\n",
+			ctxp->dane_status);
+		abort();
+	}
+
+	bev= ctxp->dane_tls_bev;
+	ctxp->dane_tls_bev= NULL;
+
+	ssl= bufferevent_openssl_get_ssl(bev);
+	fprintf(stderr, "dane_check: ssl = %p\n", ssl);
+
+	cert = SSL_get_peer_certificate(ssl);
+	if (!cert) {
+		fprintf(stderr,
+		"dane_check: SSL_get_peer_certificate failed\n");
+		goto cleanup;
+	}
+
+	store= X509_STORE_new();
+	if (X509_STORE_load_locations(store, NULL,
+		"/usr/lib/ssl/certs") != 1) {
+		fprintf(stderr,
+		"dane_check: X509_STORE_load_locations failed\n");
+		goto cleanup;
+	}
+	ldns_r= ldns_dane_verify(ctxp->dane_rr_list, cert, NULL, store);
+
+	fprintf(stderr, "ldns_r == %d\n", ldns_r);
+
+	switch(ldns_r)
+	{
+	case LDNS_STATUS_OK:
+		/* Record the fact that we passed a bev to the user. */
+		ctxp->user_busy= 1;
+		ctxp->user_cb(bev, ctxp->user_ref);
+		break;
+
+	case LDNS_STATUS_DANE_TLSA_DID_NOT_MATCH:
+		fprintf(stderr, "dane_check: should record ldns error\n");
+
+		/* Drop the bev */
+		bufferevent_free(bev);
+                bev= NULL;
+		
+		break;
+ 		
+	default:
+		fprintf(stderr, "dane_check: unknown ldns result\n", ldns_r);
+		abort();
+	}
+	
+cleanup:
+	fprintf(stderr, "dane_check: should do cleanup\n");
+}
+
+/* Called by TLS to tell DANE about a new TLS connection. This function
+ * returns 0 if there is no space, and 1 if the connection is accepted.
+ * DANE checks the connects and passes it to the user if it validates or
+ * if there is no DANE record.
+ */
+static int dane_accept_tls_bev(struct work_ctx *ctxp, struct bufferevent *bev)
+{
+	fprintf(stderr, "in dane_accept_tls_bev\n");
+	if (ctxp->dane_tls_bev)
+		return 0;	/* Already got something. */
+	ctxp->dane_tls_bev= bev;
+	dane_check(ctxp);
+
+	/* Get more connections if the one we got didn't work out */
+	while(!ctxp->dane_tls_bev && !ctxp->user_busy)
+	{
+		fprintf(stderr, "dane_accept_tls_bev: calling tls_get\n");
+		bev= tls_get(ctxp);
+		if (!bev)
+			break;
+		ctxp->dane_tls_bev= bev; bev= NULL;
+		dane_check(ctxp);
+	}
+
+	return 1;
+}
+
+static void timeout_callback(evutil_socket_t fd, short events, void *ref)
+{
+	struct work_ctx *ctxp;
+	struct timespec now;
+	struct timeval timeout;
+
+	ctxp= ref;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	fprintf(stderr, "timeout_callback: now %d.%09d\n",
+		now.tv_sec, now.tv_nsec);
+	fprintf(stderr, "timeout_callback: target %d.%09d\n",
+		ctxp->ipv6_timeout.tv_sec, ctxp->ipv6_timeout.tv_nsec);
+
+	if (now.tv_sec < ctxp->ipv6_timeout.tv_sec ||
+		(now.tv_sec == ctxp->ipv6_timeout.tv_sec &&
+		now.tv_nsec < ctxp->ipv6_timeout.tv_nsec))
+	{
+		/* Set timer */
+		timeout.tv_sec= ctxp->ipv6_timeout.tv_sec - now.tv_sec;
+		timeout.tv_usec= (ctxp->ipv6_timeout.tv_nsec - now.tv_nsec)/
+			1000 + 1;
+
+		fprintf(stderr, "timeout %d.%06d\n",
+			timeout.tv_sec, timeout.tv_usec);
+		if (timeout.tv_usec < 0)
+		{
+			timeout.tv_usec += US_PER_SEC;
+			timeout.tv_sec--;
+		}
+		fprintf(stderr, "timeout %d.%06d\n",
+			timeout.tv_sec, timeout.tv_usec);
+		evtimer_add(ctxp->ipv6_to_event, &timeout);
+		return;
+	}
+
+	/* The state should be STATE_DNS_IPV6_WAITING. Ignore other states */
+	if (ctxp->state != STATE_DNS_IPV6_WAITING)
+	{
+		fprintf(stderr, "timeout_callback: bad state %d\n",
+			ctxp->state);
+		return;
+	}
+
+	/* Start connecting */
+	ctxp->state= STATE_DNS_IPV6_CONNECTING;
+	do_connect(ctxp);
+}
+
+static void connect_callback(evutil_socket_t fd, short events, void *ref)
+{
+	int i, r, error, sock;
+	socklen_t socklen;
+	struct work_ctx *ctxp;
+	struct addrlist *ap;
+	void (*user_cb)(int fd, void *ref);
+	void *user_ref;
+	SSL *tls;
+
+	ctxp= ref;
+
+	/* Just look at all sockets */
+	for (i= 0, ap= ctxp->alist; i<ctxp->naddrs; i++, ap++)
+	{
+		if (ap->socket == fd)
+			break;
+	}
+
+	if (i >= ctxp->naddrs)
+	{
+		/* Weird. */
+		fprintf(stderr, "connect_callback: socket not found\n");
+		return;
+
+	}
+
+	/* Check for error */
+	socklen= sizeof(error);
+	r= getsockopt(fd, SOL_SOCKET, SO_ERROR, &error, &socklen);
+	if (r == -1)
+	{
+		/* Weird */
+		ap->error= errno;
+		do_connect(ctxp);
+		return;
+	}
+	if (error)
+	{
+		ap->error= error;
+		do_connect(ctxp);
+		return;
+	}
+
+	sock= ap->socket;
+
+	assert(ap->event);
+	event_del(ap->event);
+	event_free(ap->event);
+	ap->event= NULL;
+
+	fprintf(stderr,  "connect_callback: starting SSL for fd %d\n", sock);
+
+	if (!ctxp->tls_ctx)
+	{
+		ctxp->tls_ctx= SSL_CTX_new(TLS_method());
+	}
+
+	tls= SSL_new(ctxp->tls_ctx);
+	fprintf(stderr, "connect_callback: tls = %p\n", tls);
+
+	assert(!ap->bev);
+	ap->bev= bufferevent_openssl_socket_new(ctxp->base->event_base,
+		sock, tls, BUFFEREVENT_SSL_CONNECTING, BEV_OPT_CLOSE_ON_FREE);
+
+	bufferevent_setcb(ap->bev, read_callback, write_callback, 
+		event_callback, ctxp);
+
+
+}
+
+static void connect_to_callback(evutil_socket_t fd, short events, void *ref)
+{
+	struct work_ctx *ctxp;
+
+	ctxp= ref;
+
+	fprintf(stderr, "connect_to_callback: restarting connect\n");
+	do_connect(ctxp);
+}
+
+static void read_callback(struct bufferevent *bev, void *ctx)
+{
+	fprintf(stderr, "in read_callback\n");
+}
+
+static void write_callback(struct bufferevent *bev, void *ctx)
+{
+	fprintf(stderr, "in write_callback\n");
+}
+
+static void event_callback(struct bufferevent *bev, short what, void *ref)
+{
+	int i;
+	struct work_ctx *ctxp;
+	struct addrlist *ap;
+	struct bufferevent *lbev;
+
+	ctxp= ref;
+
+	fprintf(stderr, "in event_callback, what 0x%x\n", what);
+
+	if (what != BEV_EVENT_CONNECTED)
+	{
+		fprintf(stderr,
+			"event_callback, TLS connect failed with 0x%x\n",
+			what);
+		
+	}
+
+	/* Stop connect_to_event. We don't need more connections
+	 * at this moment.
+	 */
+	assert(ctxp->connect_to_event);
+	evtimer_del(ctxp->connect_to_event);
+
+	/* Find bev */
+	for (i= 0, ap= ctxp->alist; i<ctxp->naddrs; i++, ap++)
+	{
+		if (ap->bev == bev)
+			break;
+	}
+
+	if (i >= ctxp->naddrs)
+	{
+		/* Not found. Weird */
+		fprintf(stderr,
+			"event_callback: bev not found, weird\n");
+		return;
+	}
+
+	/* Found the right event */
+	ap->bev= NULL;
+	ap->socket= -1;
+	ap->tls_completed= 1;
+
+	/* Tell DANE */
+	if (!dane_accept_tls_bev(ctxp, bev))
+	{
+		/* Dane did not accept this connection */
+		ctxp->tls_bev[ctxp->ntls]= bev; bev= NULL;
+		ctxp->ntls++;
+	}
+
+	return;
+
+#if 0
+	fprintf(stderr, "event_callback: should handle DANE\n");
+	abort();
+
+	/* Kill timers */
+	if (ctxp->ipv6_to_event)
+	{
+		evtimer_del(ctxp->ipv6_to_event);
+		event_free(ctxp->ipv6_to_event);
+		ctxp->ipv6_to_event= NULL;
+	}
+
+	assert(ctxp->connect_to_event);
+	evtimer_del(ctxp->connect_to_event);
+	event_free(ctxp->connect_to_event);
+	ctxp->connect_to_event= NULL;
+
+	/* Find bev */
+	for (i= 0, ap= ctxp->alist; i<ctxp->naddrs; i++, ap++)
+	{
+		if (ap->bev == bev)
+		{
+			/* Found the right event */
+			ap->bev= NULL;
+			ap->socket= -1;
+			continue;
+		}
+		if (!ap->bev)
+		{
+			if (ap->socket != -1)
+			{
+				assert(ap->event);
+				event_del(ap->event);
+				event_free(ap->event);
+				ap->event= NULL;
+
+				close(ap->socket);
+				ap->socket= -1;
+			}
+			continue;
+		}
+
+		lbev= ap->bev;
+		ap->bev= NULL;
+		bufferevent_free(lbev);
+		lbev= NULL;
+	}
+
+	ctxp->user_cb(bev, ctxp->user_ref);
+#endif
+}
+
+static void merge_v4_v6(struct work_ctx *ctxp)
+{
+	int i, j, any, best, prefer_ipv6;
+	struct addrlist *ap;
+
+	for (i= 0, ap= ctxp->alist; i<ctxp->naddrs; i++, ap++)
+		ap->selected= 0;
+
+	/* Try to interleave IPv4 and IPv6 addresses */
+	prefer_ipv6= 1;
+	for (i= 0; i<ctxp->naddrs; i++)
+	{
+		best= -1;
+		any= -1;
+		for (j= 0, ap= ctxp->alist; j<ctxp->naddrs; j++, ap++)
+		{
+			if (ap->selected)
+				continue;
+
+			if (any == -1)
+				any= j;
+			if (prefer_ipv6)
+			{
+				if (ap->addr.ss_family == AF_INET6)
+				{
+					best= j;
+					prefer_ipv6= 0;	/* IPv4 next time */
+					break;
+				}
+			}
+			else
+			{
+				if (ap->addr.ss_family == AF_INET)
+				{
+					best= j;
+					prefer_ipv6= 1;	/* IPv6 next time */
+					break;
+				}
+			}
+		}
+		if (best != -1)
+		{
+			ctxp->mlist[i]= &ctxp->alist[best];
+			ctxp->alist[best].selected= 1;
+			continue;
+		}
+		assert(any != -1);
+		ctxp->mlist[i]= &ctxp->alist[any];
+		ctxp->alist[any].selected= 1;
+	}
+}
+
+static void do_connect(struct work_ctx *ctxp)
+{
+	int i, r, done, do_timeout;
+	struct addrlist *ap;
+	struct timespec now, timeout_ns;
+	struct timeval timeout;
+
+	fprintf(stderr, "in do_connect\n");
+
+	done= 1;	/* Assume we are done. Will be cleared when
+			 * there is work to do.
+			 */
+	do_timeout= 0;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	for (i= 0; i<ctxp->naddrs; i++)
+	{
+		ap= ctxp->mlist[i];
+
+		if (ap->error)
+		{
+			continue;	/* This address already
+					 * failed.
+					 */
+		}
+		if (ap->tls_completed)
+			continue;	/* This address is done */
+
+		if (ap->socket == -1)
+		{
+			r= socket(ap->addr.ss_family, SOCK_STREAM, 0);
+			if (r == -1)
+			{
+				ap->error= errno;
+				continue;
+			}
+
+			ap->socket= r;
+
+			/* Switch to nonblocking */
+			fcntl(ap->socket, F_SETFL,
+				fcntl(ap->socket, F_GETFL) |
+				O_NONBLOCK);
+
+			r= connect(ap->socket, (struct sockaddr *)&ap->addr,
+				ap->addrlen);
+			if (r == 0)
+			{
+				/* This is weird, a nonblocking
+				 * connect that succeeds. In any case,
+				 * we got what we wanted.
+				 */
+				done= 1; /* signal that we are done */
+				break;
+			}
+			else if (errno == EINPROGRESS)
+			{
+				/* This is what we expect, fall
+				 * through.
+				 */
+			}
+			else
+			{
+				/* Some kind of error */
+				ap->error= errno;
+				continue;
+			}
+
+			ap->timeout= 0;
+			ap->endtime= now;
+			ts_add_ns(&ap->endtime, TIMEOUT_NS);
+
+			assert(!ap->event);
+			ap->event= event_new(ctxp->base->event_base,
+				ap->socket, EV_WRITE, connect_callback, ctxp);
+			event_add(ap->event, NULL);
+		}
+
+		assert(ap->socket != -1 && ap->error == 0);
+		done= 0;
+
+		if (!ap->timeout)
+		{
+			if (ap->endtime.tv_sec < now.tv_sec ||
+				(ap->endtime.tv_sec == now.tv_sec &&
+				ap->endtime.tv_nsec <= now.tv_nsec))
+			{
+				/* We got a timeout, move to the
+				 * next address.
+				 */
+				ap->timeout= 1;
+				continue;
+			}
+
+			ts_sub(&timeout_ns, &ap->endtime, &now);
+			tv_from_ts(&timeout, &timeout_ns);
+			do_timeout= 1;
+			break;
+		}
+	}
+
+	if (done)
+	{
+		if (i < ctxp->naddrs)
+		{
+			fprintf(stderr, "do_connect: found one\n");
+			return;	/* Got something */
+		}
+
+		/* All addresses failed. */
+		fprintf(stderr, "do_connect: all failed\n");
+		assert(ctxp->alist[0].error);
+		return;
+	}
+
+	if (do_timeout)
+	{
+		if (!ctxp->connect_to_event)
+		{
+			ctxp->connect_to_event=
+				evtimer_new(ctxp->base->event_base,
+				connect_to_callback, ctxp);
+		}
+		evtimer_add(ctxp->connect_to_event, &timeout);
+	}
+
+}
+
+static void ts_add_ns(struct timespec *tsp, long ns)
+{
+	tsp->tv_sec += TIMEOUT_NS / NS_PER_SEC;
+	tsp->tv_nsec += TIMEOUT_NS % NS_PER_SEC;
+	if (tsp->tv_nsec >= NS_PER_SEC)
+	{
+		tsp->tv_nsec -= NS_PER_SEC;
+		tsp->tv_sec++;
+	}
+}
+
+static void ts_sub(struct timespec *res,
+	struct timespec *v1, struct timespec *v2)
+{
+	res->tv_sec= v1->tv_sec-v2->tv_sec;
+	res->tv_nsec= v1->tv_nsec-v2->tv_nsec;
+	if (res->tv_nsec < 0)
+	{
+		res->tv_nsec += NS_PER_SEC;
+		res->tv_sec--;
+	}
+}
+
+static void tv_from_ts(struct timeval *tv, struct timespec *ts)
+{
+	tv->tv_sec= ts->tv_sec;
+	tv->tv_usec= ts->tv_nsec/1000;
+	if (ts->tv_nsec % 1000)
+		tv->tv_usec++;	/* Round up */
+}

--- a/proto6/connectbyname.c
+++ b/proto6/connectbyname.c
@@ -323,7 +323,7 @@ static void dns_callback(getdns_context *context,
 			gdns_r);
 		goto cleanup;
 	}
-	printf("len %d\n", len);
+	printf("len %lu\n", len);
 	got_ipv4= 0;
 	got_ipv6= 0;
 	for (i= 0; i<len; i++)
@@ -352,7 +352,7 @@ static void dns_callback(getdns_context *context,
 			goto cleanup;
 		}
 		fprintf(stderr, "dns_callback: %d type %.*s\n", i,
-			addr_type->size, addr_type->data);
+			(int)addr_type->size, addr_type->data);
 
 		if (addr_type->size != 4)
 		{
@@ -420,18 +420,18 @@ static void dns_callback(getdns_context *context,
 			ctxp->ipv6_to_event= evtimer_new(ctxp->base->event_base,
 				timeout_callback, ctxp);
 			clock_gettime(CLOCK_MONOTONIC, &timeout);
-			fprintf(stderr, "dns_callback: now %d.%09d\n",
+			fprintf(stderr, "dns_callback: now %ld.%09ld\n",
 				timeout.tv_sec, timeout.tv_nsec);
 			timeout.tv_nsec += TIMEOUT_NS % NS_PER_SEC;
 			timeout.tv_sec += TIMEOUT_NS / NS_PER_SEC;
-			fprintf(stderr, "dns_callback: timeout %d.%09d\n",
+			fprintf(stderr, "dns_callback: timeout %ld.%09ld\n",
 				timeout.tv_sec, timeout.tv_nsec);
 			if (timeout.tv_nsec >= NS_PER_SEC)
 			{
 				timeout.tv_nsec -= NS_PER_SEC;
 				timeout.tv_sec++;
 			}
-			fprintf(stderr, "dns_callback: timeout %d.%09d\n",
+			fprintf(stderr, "dns_callback: timeout %ld.%09ld\n",
 				timeout.tv_sec, timeout.tv_nsec);
 			ctxp->ipv6_timeout= timeout;
 
@@ -851,7 +851,7 @@ static void dane_check(struct work_ctx *ctxp)
 		break;
  		
 	default:
-		fprintf(stderr, "dane_check: unknown ldns result\n", ldns_r);
+		fprintf(stderr, "dane_check: unknown ldns result %d\n", ldns_r);
 		abort();
 	}
 	
@@ -894,9 +894,9 @@ static void timeout_callback(evutil_socket_t fd, short events, void *ref)
 
 	ctxp= ref;
 	clock_gettime(CLOCK_MONOTONIC, &now);
-	fprintf(stderr, "timeout_callback: now %d.%09d\n",
+	fprintf(stderr, "timeout_callback: now %ld.%09ld\n",
 		now.tv_sec, now.tv_nsec);
-	fprintf(stderr, "timeout_callback: target %d.%09d\n",
+	fprintf(stderr, "timeout_callback: target %ld.%09ld\n",
 		ctxp->ipv6_timeout.tv_sec, ctxp->ipv6_timeout.tv_nsec);
 
 	if (now.tv_sec < ctxp->ipv6_timeout.tv_sec ||
@@ -908,14 +908,14 @@ static void timeout_callback(evutil_socket_t fd, short events, void *ref)
 		timeout.tv_usec= (ctxp->ipv6_timeout.tv_nsec - now.tv_nsec)/
 			1000 + 1;
 
-		fprintf(stderr, "timeout %d.%06d\n",
+		fprintf(stderr, "timeout %ld.%06ld\n",
 			timeout.tv_sec, timeout.tv_usec);
 		if (timeout.tv_usec < 0)
 		{
 			timeout.tv_usec += US_PER_SEC;
 			timeout.tv_sec--;
 		}
-		fprintf(stderr, "timeout %d.%06d\n",
+		fprintf(stderr, "timeout %ld.%06ld\n",
 			timeout.tv_sec, timeout.tv_usec);
 		evtimer_add(ctxp->ipv6_to_event, &timeout);
 		return;

--- a/proto6/connectbyname.h
+++ b/proto6/connectbyname.h
@@ -1,0 +1,28 @@
+/*
+connectbyname.h
+
+Interface for connectbyname
+*/
+
+#include <getdns/getdns.h>
+
+struct cbn_context
+{
+	struct event_base *event_base;
+	getdns_context *getdns_ctx;
+};
+
+struct bufferevent;
+typedef void (*cbn_callback_T)(struct bufferevent *bev, void *ref);
+
+int cbn_init(struct cbn_context *cbn_ctx, struct event_base *event_base);
+void cbn_clean(struct cbn_context *cbn_ctx);
+
+int connectbyname(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname, int *fdp);
+
+int connectbyname_asyn(struct cbn_context *cbn_ctx,
+	const char *hostname, const char *servname,
+	cbn_callback_T user_cb, void *user_ref, void **refp);
+
+void connectbyname_free(void *ref);

--- a/proto6/get443.c
+++ b/proto6/get443.c
@@ -1,0 +1,168 @@
+/*
+get443.c
+
+Send a HTTP GET request to a target and print the result.
+*/
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+
+#include <event2/event.h>
+#include <event2/bufferevent.h>
+
+#include "connectbyname.h"
+
+struct state
+{
+	char *hostname;
+	struct event_base *event_base;
+	struct event *event;
+	void *cbn_ref;
+
+	struct cbn_context cbn_ctx;
+};
+
+static void callback(struct bufferevent *bev, void *ref);
+static void read_callback(struct bufferevent *bev, void *ref);
+static void event_callback(struct bufferevent *bev, short what, void *ref);
+static void usage(void);
+
+int main(int argc, char *argv[])
+{
+	int r, s;
+	FILE *f;
+	char *hostname;
+	void *ref;
+	struct event_base *event_base;
+	char buf[1024];
+	struct state state;
+
+	if (argc != 2)
+		usage();
+
+	hostname= argv[1];
+	state.hostname= hostname;
+
+	event_enable_debug_mode();
+	event_base= event_base_new();
+	state.event_base= event_base;
+	cbn_init(&state.cbn_ctx, event_base);
+	r= connectbyname_asyn(&state.cbn_ctx, hostname, "https",
+		callback, &state, &ref);
+	if (r)
+	{
+		fprintf(stderr, "connectbyname failed: %d\n", r);
+		exit(1);
+	}
+	fprintf(stderr, "main: &state: %p, ref %p\n", &state, ref);
+	state.cbn_ref= ref;
+
+	r= event_base_dispatch(event_base);
+	fprintf(stderr, "event_base_dispatch returned: %d\n", r);
+	abort();
+
+	f= fdopen(s, "r+");
+	if (f == NULL)
+	{
+		fprintf(stderr, "fdopen failed: %s\n", strerror(errno));
+		exit(1);
+	}
+	fprintf(f, "GET / HTTP/1.1\r\nHost: %s\r\n\r\n", hostname);
+	fflush(f);
+	shutdown(s, SHUT_WR);
+	for(;;)
+	{
+		r= fread(buf, 1, sizeof(buf), f);
+		if (r == 0)
+		{
+			if (feof(f))
+				break;
+			fprintf(stderr, "read error: %s\n", strerror(errno));
+			exit(1);
+		}
+		fwrite(buf, r, 1, stdout);
+	}
+	fclose(f);
+	exit(0);
+}
+
+static void callback(struct bufferevent *bev, void *ref)
+{
+	struct state *statep;
+	char reqline[80];
+
+	statep= ref;
+
+	snprintf(reqline, sizeof(reqline),
+		"GET / HTTP/1.1\r\nHost: %s\r\n\r\n", statep->hostname);
+	
+	/* Assume write will not block */
+	bufferevent_write(bev, reqline, strlen(reqline));
+	bufferevent_enable(bev, EV_READ);
+	bufferevent_setcb(bev, read_callback, NULL, event_callback, ref);
+}
+
+static void read_callback(struct bufferevent *bev, void *ref)
+{
+	int r;
+	char line[1024];
+
+	printf("\n\nin read_callback\n\n");
+
+	for (;;)
+	{
+		r= bufferevent_read(bev, line, sizeof(line));
+		if (r == 0)
+			break;
+		if (r == -1)
+		{
+			fprintf(stderr, "read error %s\n", strerror(errno));
+			exit(1);
+		}
+		printf("%.*s", r, line);
+	}
+}
+
+static void event_callback(struct bufferevent *bev, short what, void *ref)
+{
+	struct state *statep;
+
+	statep= ref;
+
+	if ((what & (BEV_EVENT_READING|BEV_EVENT_EOF)) ==
+		(BEV_EVENT_READING|BEV_EVENT_EOF))
+	{
+		/* EOF */
+
+		/* Free bufferevent */
+		bufferevent_free(bev);
+		bev= NULL;
+
+		fprintf(stderr, "event_callback: statep: %p, ref %p\n",
+			statep, statep->cbn_ref);
+		
+		/* Connectbyname call */
+		connectbyname_free(statep->cbn_ref);
+		statep->cbn_ref= NULL;
+
+		/* Connectbyname context */
+		cbn_clean(&statep->cbn_ctx);
+
+		/* event base */
+		event_base_free(statep->event_base);
+		statep->event_base= NULL;
+
+		exit(0);
+	}
+	fprintf(stderr, "event_callback: what %d\n", what);
+}
+
+static void usage(void)
+{
+	fprintf(stderr, "get80 <hostname>\n");
+	exit(1);
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -3,5 +3,5 @@ libconnectbyname_la_SOURCES = connectbyname.c
 include_HEADERS = connectbyname.h
 
 bin_PROGRAMS = connectbyname
-connectbyname_SOURCES = cbn-client.c
+connectbyname_SOURCES = cbn.c
 connectbyname_LDADD = libconnectbyname.la

--- a/src/cbn.c
+++ b/src/cbn.c
@@ -1,5 +1,5 @@
 /*
- * cbn-client.c - User program to test libconnectbyname functionality
+ * cbn.c - User program to test libconnectbyname functionality
  *
  * Copyright (c) 2017, NLnet Labs. All rights reserved.
  * 
@@ -39,7 +39,8 @@
 
 int main()
 {
-	printf("nothing yet, sorry...\n");
+	printf("sizeof(struct cbn_policy): %lu\n", sizeof(struct cbn_policy));
+	printf("sizeof(struct cbn): %lu\n", sizeof(struct cbn));
 	return 0;
 }
 


### PR DESCRIPTION
This PR is used to comment inline in the PR.
The suggestions from @gthess have been merged, but he had some additional notes:

Hi Philip, just went through the text and I found some nits and typos which are addressed with this PR.

I also have some comments below:
- BADPROXYPOLICY is not introduced (either text or definition) before the protocol specification section where it is first mentioned.
- For the PROXY CONTROL option, should flags on byte 6 only include the allow flags and byte 8 then only the disallow flags? Then there is more space for future transports.
- In the byte representation of the options all optional fields should mention that they can have zero in the length field.
- From a first read I don't fully grasp how the PROXY SCOPE option helps.